### PR TITLE
Formatting that takes display width into account

### DIFF
--- a/ftfy/__init__.py
+++ b/ftfy/__init__.py
@@ -17,7 +17,7 @@ from ftfy.formatting import display_ljust
 from ftfy.compatibility import is_printable
 import unicodedata
 
-__version__ = '4.1.0'
+__version__ = '4.0.0'
 
 
 def fix_text(text,

--- a/ftfy/__init__.py
+++ b/ftfy/__init__.py
@@ -13,10 +13,11 @@ import ftfy.bad_codecs
 ftfy.bad_codecs.ok()
 
 from ftfy import fixes
+from ftfy.formatting import display_ljust
 from ftfy.compatibility import is_printable
 import unicodedata
 
-__version__ = '4.0.0'
+__version__ = '4.1.0'
 
 
 def fix_text(text,
@@ -386,7 +387,7 @@ def explain_unicode(text):
         U+00B0  °       [So] DEGREE SIGN
         U+0029  )       [Pe] RIGHT PARENTHESIS
         U+256F  ╯       [So] BOX DRAWINGS LIGHT ARC UP AND LEFT
-        U+FE35  ︵       [Ps] PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
+        U+FE35  ︵      [Ps] PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
         U+0020          [Zs] SPACE
         U+253B  ┻       [So] BOX DRAWINGS HEAVY UP AND HORIZONTAL
         U+2501  ━       [So] BOX DRAWINGS HEAVY HORIZONTAL
@@ -397,8 +398,8 @@ def explain_unicode(text):
             display = char
         else:
             display = char.encode('unicode-escape').decode('ascii')
-        print('U+{code:04X}  {display:<7} [{category}] {name}'.format(
-            display=display,
+        print('U+{code:04X}  {display} [{category}] {name}'.format(
+            display=display_ljust(display, 7),
             code=ord(char),
             category=unicodedata.category(char),
             name=unicodedata.name(char, '<unknown>')

--- a/ftfy/formatting.py
+++ b/ftfy/formatting.py
@@ -17,11 +17,15 @@ def character_width(char):
     exception. This assumption will go wrong, for example, if your display is
     actually on a Japanese flip-phone... but let's assume it isn't.
 
-    If this character is a control code, the idea of it having a "width"
-    probably doesn't even apply, because it will probably have some other
-    effect on your terminal. For example, there's no sensible width for a
-    line break. We return the default of 1 in the absence of anything sensible
-    to do there.
+    Combining marks and formatting codepoints do not advance the cursor,
+    so their width is 0.
+
+    If the character is a particular kind of control code -- the kind
+    represented by the lowest bytes of ASCII, with Unicode category Cc -- the
+    idea of it having a "width" probably doesn't even apply, because it will
+    probably have some other effect on your terminal. For example, there's no
+    sensible width for a line break. We return the default of 1 in the absence
+    of anything sensible to do there.
 
     >>> character_width('車')
     2

--- a/ftfy/formatting.py
+++ b/ftfy/formatting.py
@@ -1,0 +1,141 @@
+from unicodedata import east_asian_width, combining, category, normalize
+
+
+def character_width(char):
+    """
+    Determine the width that a character is likely to be displayed as in
+    a monospaced terminal. The width will always be 0, 1, or 2.
+
+    We are assuming that the character will appear in a modern, Unicode-aware
+    terminal emulator, where CJK characters -- plus characters designated
+    "fullwidth" by CJK encodings -- will span two character cells. (Maybe
+    it's an over-simplification to call these displays "monospaced".)
+
+    When a character width is "Ambiguous", we assume it to span one character
+    cell, because we assume that the monospaced display you're using is
+    designed mostly to display Western characters with CJK characters as the
+    exception. This assumption will go wrong, for example, if your display is
+    actually on a Japanese flip-phone... but let's assume it isn't.
+
+    If this character is a control code, the idea of it having a "width"
+    probably doesn't even apply, because it will probably have some other
+    effect on your terminal. For example, there's no sensible width for a
+    line break. We return the default of 1 in the absence of anything sensible
+    to do there.
+
+    >>> character_width('車')
+    2
+    >>> character_width('A')
+    1
+    >>> character_width('\N{SOFT HYPHEN}')
+    0
+    """
+    if combining(char) != 0:
+        # Combining characters don't advance the cursor; they modify the
+        # previous character instead.
+        return 0
+    elif east_asian_width(char) in 'FW':
+        # Characters designated Wide (W) or Fullwidth (F) will take up two
+        # columns in many Unicode-aware terminal emulators.
+        return 2
+    elif category(char) == 'Cf':
+        # Characters in category Cf are un-printable formatting characters
+        # that do not advance the cursor, such as zero-width spaces or
+        # right-to-left marks.
+        return 0
+    else:
+        return 1
+
+
+def monospaced_width(text):
+    """
+    Return the number of character cells that this string is likely to occupy
+    when displayed in a monospaced, modern, Unicode-aware terminal emulator.
+    We refer to this as the "display width" of the string.
+
+    This can be useful for formatting text that may contain non-spacing
+    characters, or CJK characters that take up two character cells.
+
+    >>> monospaced_width('ちゃぶ台返し')
+    12
+    >>> len('ちゃぶ台返し')
+    6
+    """
+    # NFC-normalize the text first, so that we don't need special cases for
+    # Hangul jamo.
+    text = normalize('NFC', text)
+    return sum([character_width(char) for char in text])
+
+
+def display_ljust(text, width, fillchar=' '):
+    """
+    Return `text` left-justified in a Unicode string whose display width,
+    in a monospaced terminal, should be at least `width` character cells.
+    The rest of the string will be padded with `fillchar`, which must be
+    a width-1 character.
+
+    "Left" here means toward the beginning of the string, which may actually
+    appear on the right in an RTL context. This is similar to the use of the
+    word "left" in "left parenthesis".
+
+    >>> lines = ['Table flip', '(╯°□°)╯︵ ┻━┻', 'ちゃぶ台返し']
+    >>> for line in lines:
+    ...     print(display_ljust(line, 20, '▒'))
+    Table flip▒▒▒▒▒▒▒▒▒▒
+    (╯°□°)╯︵ ┻━┻▒▒▒▒▒▒▒
+    ちゃぶ台返し▒▒▒▒▒▒▒▒
+    """
+    if character_width(fillchar) != 1:
+        raise ValueError("The padding character must have display width 1")
+    text_width = monospaced_width(text)
+    padding = max(0, width - text_width)
+    return text + fillchar * padding
+
+
+def display_rjust(text, width, fillchar=' '):
+    """
+    Return `text` right-justified in a Unicode string whose display width,
+    in a monospaced terminal, should be at least `width` character cells.
+    The rest of the string will be padded with `fillchar`, which must be
+    a width-1 character.
+
+    "Right" here means toward the end of the string, which may actually be on
+    the left in an RTL context. This is similar to the use of the word "right"
+    in "right parenthesis".
+
+    >>> lines = ['Table flip', '(╯°□°)╯︵ ┻━┻', 'ちゃぶ台返し']
+    >>> for line in lines:
+    ...     print(display_rjust(line, 20, '▒'))
+    ▒▒▒▒▒▒▒▒▒▒Table flip
+    ▒▒▒▒▒▒▒(╯°□°)╯︵ ┻━┻
+    ▒▒▒▒▒▒▒▒ちゃぶ台返し
+    """
+    if character_width(fillchar) != 1:
+        raise ValueError("The padding character must have display width 1")
+    text_width = monospaced_width(text)
+    padding = max(0, width - text_width)
+    return fillchar * padding + text
+
+
+def display_center(text, width, fillchar=' '):
+    """
+    Return `text` centered in a Unicode string whose display width, in a
+    monospaced terminal, should be at least `width` character cells. The rest
+    of the string will be padded with `fillchar`, which must be a width-1
+    character.
+
+    >>> lines = ['Table flip', '(╯°□°)╯︵ ┻━┻', 'ちゃぶ台返し']
+    >>> for line in lines:
+    ...     print(display_center(line, 20, '▒'))
+    ▒▒▒▒▒Table flip▒▒▒▒▒
+    ▒▒▒(╯°□°)╯︵ ┻━┻▒▒▒▒
+    ▒▒▒▒ちゃぶ台返し▒▒▒▒
+    """
+    if character_width(fillchar) != 1:
+        raise ValueError("The padding character must have display width 1")
+    text_width = monospaced_width(text)
+    padding = max(0, width - text_width)
+    left_padding = padding // 2
+    right_padding = padding - left_padding
+    return fillchar * left_padding + text + fillchar * right_padding
+

--- a/ftfy/formatting.py
+++ b/ftfy/formatting.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+from __future__ import unicode_literals, division
 from unicodedata import east_asian_width, combining, category, normalize
 
 

--- a/ftfy/formatting.py
+++ b/ftfy/formatting.py
@@ -91,8 +91,7 @@ def display_ljust(text, width, fillchar=' '):
     """
     if character_width(fillchar) != 1:
         raise ValueError("The padding character must have display width 1")
-    text_width = monospaced_width(text)
-    padding = max(0, width - text_width)
+    padding = max(0, width - monospaced_width(text))
     return text + fillchar * padding
 
 
@@ -116,8 +115,7 @@ def display_rjust(text, width, fillchar=' '):
     """
     if character_width(fillchar) != 1:
         raise ValueError("The padding character must have display width 1")
-    text_width = monospaced_width(text)
-    padding = max(0, width - text_width)
+    padding = max(0, width - monospaced_width(text))
     return fillchar * padding + text
 
 
@@ -137,8 +135,7 @@ def display_center(text, width, fillchar=' '):
     """
     if character_width(fillchar) != 1:
         raise ValueError("The padding character must have display width 1")
-    text_width = monospaced_width(text)
-    padding = max(0, width - text_width)
+    padding = max(0, width - monospaced_width(text))
     left_padding = padding // 2
     right_padding = padding - left_padding
     return fillchar * left_padding + text + fillchar * right_padding


### PR DESCRIPTION
Add functions that do the equivalent of `str.ljust` and friends, but apply to the width of the text when displayed in a terminal, instead of the length of the string in codepoints.

This is not strictly related to fixing text. However, the ragged columns in `explain_unicode` were bothering me, and I heard from someone else who wished these functions existed as well.