### PR TITLE
Fix stdin decoding on Python 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 4.1.1 (April 13, 2016)
+
+- Bug fix: in the command-line interface, the `-e` option had no effect on
+  Python 3 when using standard input. Now, it correctly lets you specify
+  a different encoding for standard input.
+
 ## Version 4.1.0 (February 25, 2016)
 
 Heuristic changes:

--- a/ftfy/__init__.py
+++ b/ftfy/__init__.py
@@ -17,7 +17,7 @@ from ftfy.formatting import display_ljust
 from ftfy.compatibility import is_printable
 import unicodedata
 
-__version__ = '4.1.0'
+__version__ = '4.1.1'
 
 
 def fix_text(text,

--- a/ftfy/cli.py
+++ b/ftfy/cli.py
@@ -5,7 +5,8 @@ from ftfy import fix_file, __version__
 
 import sys
 import io
-ENCODE_STDIO = (sys.hexversion < 0x03000000)
+import codecs
+PY2 = (sys.hexversion < 0x03000000)
 
 
 ENCODE_ERROR_TEXT_UNIX = """ftfy error:
@@ -72,12 +73,18 @@ def main():
         encoding = None
 
     if args.filename == '-':
-        file = sys.stdin
+        # Get a standard input stream made of bytes, so we can decode it as
+        # whatever encoding is necessary.
+        if PY2:
+            file = sys.stdin
+        else:
+            file = sys.stdin.buffer
+
     else:
         file = open(args.filename, 'rb')
 
     if args.output == '-':
-        encode_output = ENCODE_STDIO
+        encode_output = PY2
         outfile = sys.stdout
     else:
         encode_output = False

--- a/ftfy/cli.py
+++ b/ftfy/cli.py
@@ -6,7 +6,7 @@ from ftfy import fix_file, __version__
 import sys
 import io
 import codecs
-PY2 = (sys.hexversion < 0x03000000)
+from ftfy.compatibility import PYTHON2
 
 
 ENCODE_ERROR_TEXT_UNIX = """ftfy error:
@@ -75,16 +75,15 @@ def main():
     if args.filename == '-':
         # Get a standard input stream made of bytes, so we can decode it as
         # whatever encoding is necessary.
-        if PY2:
+        if PYTHON2:
             file = sys.stdin
         else:
             file = sys.stdin.buffer
-
     else:
         file = open(args.filename, 'rb')
 
     if args.output == '-':
-        encode_output = PY2
+        encode_output = PYTHON2
         outfile = sys.stdout
     else:
         encode_output = False

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 setup(
     name="ftfy",
-    version='4.1.0',
+    version='4.1.1',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     license="MIT",


### PR DESCRIPTION
In the command-line interface, the `-e` option for specifying an encoding had no effect on Python 3 when using standard input, because it was using `sys.stdin`, which is already decoded. Now, it uses `sys.stdin.buffer`, so that it correctly lets you specify a different encoding for standard input.