### PR TITLE
Ability to fix windows-1250 or iso-8859-2 mojibake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Full documentation: **http://ftfy.readthedocs.org**
   — [@planarrowspace](http://twitter.com/planarrowspace)
 - “A handy piece of magic”
   — [@simonw](http://twitter.com/simonw)
+- “ftfy did the right thing right away, with no faffing about. Excellent work, solving a very tricky real-world (whole-world!) problem.”
+  — Brennan Young
 - “Hat mir die Tage geholfen. Im Übrigen bin ich der Meinung, dass wir keine komplexen Maschinen mit Computern bauen sollten solange wir nicht einmal Umlaute sicher verarbeiten können. :D”
   — [Bruno Ranieri](http://yrrsinn.de/2012/09/17/gelesen-kw37/)
 - “I have no idea when I’m gonna need this, but I’m definitely bookmarking it.”

--- a/ftfy/badness.py
+++ b/ftfy/badness.py
@@ -58,6 +58,13 @@ def _make_weirdness_regex():
     groups.append('[Ll][AaC]')
     groups.append('[AaC][Ll]')
 
+    # Match non-combining diacritics. We've already set aside the common ones
+    # like ^ (the CIRCUMFLEX ACCENT, repurposed as a caret, exponent sign,
+    # or happy eye) and assigned them to category 'o'. The remaining ones,
+    # like the diaeresis (¨), are pretty weird to see on their own instead
+    # of combined with a letter.
+    groups.append('2')
+
     # Match C1 control characters, which are almost always the result of
     # decoding Latin-1 that was meant to be Windows-1252.
     groups.append('X')
@@ -70,9 +77,9 @@ def _make_weirdness_regex():
     # - Modifier marks (M)
     # - Letter modifiers (m)
     # - Miscellaneous numbers (N)
-    # - Symbols (123)
+    # - Symbols (1 or 3, because 2 is already weird on its own)
 
-    exclusive_categories = 'MmN123'
+    exclusive_categories = 'MmN13'
     for cat1 in exclusive_categories:
         others_range = ''.join(c for c in exclusive_categories if c != cat1)
         groups.append('{cat1}[{others_range}]'.format(

--- a/ftfy/chardata.py
+++ b/ftfy/chardata.py
@@ -12,14 +12,16 @@ import itertools
 from pkg_resources import resource_string
 from ftfy.compatibility import unichr
 
-# These are the five encodings we will try to fix in ftfy, in the
+# These are the encodings we will try to fix in ftfy, in the
 # order that they should be tried.
 CHARMAP_ENCODINGS = [
     'latin-1',
     'sloppy-windows-1252',
+    'sloppy-windows-1250',
+    'iso-8859-2',
+    'sloppy-windows-1251',
     'macroman',
     'cp437',
-    'sloppy-windows-1251',
 ]
 
 

--- a/ftfy/fixes.py
+++ b/ftfy/fixes.py
@@ -126,8 +126,10 @@ def fix_text_encoding(text):
 # that these encodings will only be used if they fix multiple problems.
 ENCODING_COSTS = {
     'macroman': 2,
+    'iso-8859-2': 2,
+    'sloppy-windows-1250': 2,
+    'sloppy-windows-1251': 3,
     'cp437': 3,
-    'sloppy-windows-1251': 5
 }
 
 

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -18,7 +18,7 @@ def test_bmp_characters():
     for index in range(0xa0, 0xfffd):
         char = unichr(index)
         # Exclude code points that are not assigned
-        if unicodedata.category(char) not in ('Co', 'Cn', 'Cs', 'Mc', 'Mn'):
+        if unicodedata.category(char) not in ('Co', 'Cn', 'Cs', 'Mc', 'Mn', 'Sk'):
             garble = char.encode('utf-8').decode('latin-1')
             # Exclude characters whose re-encoding is protected by the
             # 'sequence_weirdness' metric

--- a/tests/test_real_text.py
+++ b/tests/test_real_text.py
@@ -57,6 +57,8 @@ TEST_CASES = [
     ("LiĂ¨ge Avenue de l'HĂ´pital", "Liège Avenue de l'Hôpital"),
     ("It was namedÂ â€žscarsÂ´ stonesâ€ś after the rock-climbers who got hurt while climbing on it.",
      "It was named\xa0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it."),
+    ("vedere Ă®nceĹŁoĹźatÄ\x83", "vedere înceţoşată"),
+    ("NapĂ\xadĹˇte nĂˇm !", "Napíšte nám !"),
 
     # The second test is different in iso-8859-2
     ("It was namedÂ\xa0â\x80\x9escarsÂ´ stonesâ\x80\x9c after the rock-climbers who got hurt while climbing on it.",

--- a/tests/test_real_text.py
+++ b/tests/test_real_text.py
@@ -58,6 +58,10 @@ TEST_CASES = [
     ("It was namedÂ â€žscarsÂ´ stonesâ€ś after the rock-climbers who got hurt while climbing on it.",
      "It was named\xa0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it."),
 
+    # The second test is different in iso-8859-2
+    ("It was namedÂ\xa0â\x80\x9escarsÂ´ stonesâ\x80\x9c after the rock-climbers who got hurt while climbing on it.",
+     "It was named\xa0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it."),
+
     # This one has two differently-broken layers of Windows-1252 <=> UTF-8,
     # and it's kind of amazing that we solve it.
     ('Arsenal v Wolfsburg: pre-season friendly â\x80â\x80\x9c live!',
@@ -106,7 +110,7 @@ def test_real_text():
 
     TEST_CASES contains the most interesting examples of these, often with some
     trickiness of how to decode them into the actually intended text.
-    
+
     For some reason, sampling Twitter gives no examples of text being
     accidentally decoded as Windows-1250, even though it's one of the more
     common encodings and this mojibake has been spotted in the wild. It may be

--- a/tests/test_real_text.py
+++ b/tests/test_real_text.py
@@ -6,8 +6,8 @@ from nose.tools import eq_
 
 
 TEST_CASES = [
-    ## These are excerpts from tweets actually seen on the public Twitter
-    ## stream. Usernames and links have been removed.
+    ## These are excerpts from text actually seen in the wild, mostly on
+    ## Twitter. Usernames and links have been removed.
     ("He's Justinâ¤", "He's Justin❤"),
     ("Le Schtroumpf Docteur conseille g√¢teaux et baies schtroumpfantes pour un r√©gime √©quilibr√©.",
      "Le Schtroumpf Docteur conseille gâteaux et baies schtroumpfantes pour un régime équilibré."),
@@ -55,6 +55,8 @@ TEST_CASES = [
 
     # Test Windows-1250 mixups
     ("LiĂ¨ge Avenue de l'HĂ´pital", "Liège Avenue de l'Hôpital"),
+    ("It was namedÂ â€žscarsÂ´ stonesâ€ś after the rock-climbers who got hurt while climbing on it.",
+     "It was named\xa0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it."),
 
     # This one has two differently-broken layers of Windows-1252 <=> UTF-8,
     # and it's kind of amazing that we solve it.
@@ -92,19 +94,26 @@ TEST_CASES = [
 ]
 
 
-def test_real_tweets():
+def test_real_text():
     """
-    Test with text actually found on Twitter.
+    Test with text actually found in the wild (mostly on Twitter).
 
-    I collected these test cases by listening to the Twitter streaming API for
+    I collected test cases by listening to the Twitter streaming API for
     a million or so tweets, picking out examples with high weirdness according
     to ftfy version 2, and seeing what ftfy decoded them to. There are some
     impressive things that can happen to text, even in an ecosystem that is
     supposedly entirely UTF-8.
 
-    The tweets that appear in TEST_CASES are the most interesting examples of
-    these, with some trickiness of how to decode them into the actually intended
-    text.
+    TEST_CASES contains the most interesting examples of these, often with some
+    trickiness of how to decode them into the actually intended text.
+    
+    For some reason, sampling Twitter gives no examples of text being
+    accidentally decoded as Windows-1250, even though it's one of the more
+    common encodings and this mojibake has been spotted in the wild. It may be
+    that Windows-1250 is used in places that culturally don't use Twitter much
+    (Central and Eastern Europe), and therefore nobody designs a Twitter app or
+    bot to use Windows-1250. I've collected a couple of examples of
+    Windows-1250 mojibake from elsewhere.
     """
     for orig, target in TEST_CASES:
         # make sure that the fix_encoding step outputs a plan that we can

--- a/tests/test_real_tweets.py
+++ b/tests/test_real_tweets.py
@@ -53,6 +53,9 @@ TEST_CASES = [
     ("#╨┐╤Ç╨░╨▓╨╕╨╗╤î╨╜╨╛╨╡╨┐╨╕╤é╨░╨╜╨╕╨╡", "#правильноепитание"),
     ('∆°', '∆°'),
 
+    # Test Windows-1250 mixups
+    ("LiĂ¨ge Avenue de l'HĂ´pital", "Liège Avenue de l'Hôpital"),
+
     # This one has two differently-broken layers of Windows-1252 <=> UTF-8,
     # and it's kind of amazing that we solve it.
     ('Arsenal v Wolfsburg: pre-season friendly â\x80â\x80\x9c live!',


### PR DESCRIPTION
I added `sloppy-windows-1250` and `iso-8859-2` as single-byte encodings that can be used in a mojibake-fixing plan. This fixes #61.

Windows-1250 and ISO-8859-2 are the two most common single-byte encodings that ftfy hasn't previously supported. They are used in Central and Eastern Europe. Mojibake involving these encodings can be found in the wild, but has been distinctly under-represented in my Twitter test data.

Making these plans actually fix short text required changing some heuristics. For one thing, much Windows-1250 mojibake involves miscellaneous diacritic characters (Unicode category `Sk`) showing up. We've already moved the benign characters in this category into the Other (`o`) class in build_data.py, so everything that remains (in class `2`) can be assumed to be weird.

Given previous changes to the heuristics, we can make ftfy less cautious about using odd encodings (by which I basically mean encodings from outside of American computing). I decreased some of the per-encoding costs, and found that no false positives were introduced in the test cases or in a few million live tweets.