### PR TITLE
Use Python 3's dict of HTML entities instead of html5lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 5.1 (April ??, 2017)
+
+Removed the dependency on `html5lib` by dropping support for Python 3.2.
+
+We previously used the dictionary `html5lib.constants.entities` to decode HTML
+entities.  In Python 3.3 and later, that exact dictionary is now in the
+standard library as `html.entities.html5`.
+
 ## Version 5.0.2 and 4.4.2 (March 21, 2017)
 
 Added a `MANIFEST.in` that puts files such as the license file and this

--- a/ftfy/__init__.py
+++ b/ftfy/__init__.py
@@ -10,7 +10,7 @@ import ftfy.bad_codecs
 from ftfy import fixes
 from ftfy.formatting import display_ljust
 
-__version__ = '5.0.2'
+__version__ = '5.1'
 
 
 # See the docstring for ftfy.bad_codecs to see what we're doing here.

--- a/ftfy/fixes.py
+++ b/ftfy/fixes.py
@@ -11,7 +11,7 @@ from ftfy.chardata import (possible_encoding, CHARMAP_ENCODINGS,
                            PARTIAL_UTF8_PUNCT_RE, ALTERED_UTF8_RE,
                            LOSSY_UTF8_RE, SINGLE_QUOTE_RE, DOUBLE_QUOTE_RE)
 from ftfy.badness import text_cost
-from html5lib.constants import entities
+from html import entities
 
 
 BYTES_ERROR_TEXT = """Hey wait, this isn't Unicode.
@@ -325,12 +325,12 @@ def unescape_html(text):
             except ValueError:
                 pass
         else:
-            # named entity
+            # This is a named entity; if it's a known HTML5 entity, replace
+            # it with the appropriate character.
             try:
-                text = entities[text[1:]]
+                return entities.html5[text[1:]]
             except KeyError:
-                pass
-        return text  # leave as is
+                return text
     return HTML_ENTITY_RE.sub(fixup, text)
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if sys.version_info[0] < 3:
 
 setup(
     name="ftfy",
-    version='5.0.2',
+    version='5.1',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     license="MIT",
@@ -33,14 +33,9 @@ setup(
     description="Fixes some problems with Unicode text after the fact",
     packages=['ftfy', 'ftfy.bad_codecs'],
     package_data={'ftfy': ['char_classes.dat']},
-
-    # We could drop the html5lib dependency if we drop support for Python <=
-    # 3.4, because the feature we need from html5lib is now in the standard
-    # library, as html.unescape.
-    install_requires=['html5lib', 'wcwidth'],
+    install_requires=['wcwidth'],
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -23,3 +23,4 @@ def test_entities():
     eq_(fix_text_segment('ellipsis&#x85;', normalization='NFKC'), 'ellipsis...')
     eq_(fix_text_segment('broken&#x81;'), 'broken\x81')
     eq_(unescape_html('euro &#x80;'), 'euro €')
+    eq_(unescape_html('not an entity &#20x6;'), 'not an entity &#20x6;')


### PR DESCRIPTION
I thought this would require Python 3.4, but `html.entities.html5` is an equivalent of `html5lib.constants.entities` that's available in Python 3.3 and up.

By dropping support for Python 3.2 (no big deal after dropping 2.7), we can remove the bulky dependency on `html5lib`.