### PR TITLE
Put tests of input/output pairs in common format in a JSON file

### DIFF
--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -1,0 +1,409 @@
+[
+    {
+        "label": "Low-codepoint emoji",
+        "original": "He's Justinâ\u009d¤",
+        "fixed": "He's Justin❤",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / MacRoman mix-up about smurfs",
+        "original": "Le Schtroumpf Docteur conseille g√¢teaux et baies schtroumpfantes pour un r√©gime √©quilibr√©.",
+        "fixed": "Le Schtroumpf Docteur conseille gâteaux et baies schtroumpfantes pour un régime équilibré.",
+        "enabled": true
+    },
+    {
+        "label": "Checkmark that almost looks okay as mojibake",
+        "original": "âœ” No problems",
+        "fixed": "✔ No problems",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Windows-1251 Russian mixup about futbol",
+        "original": "РґРѕСЂРѕРіРµ Р\u0098Р·-РїРѕРґ #С„СѓС‚Р±РѕР»",
+        "fixed": "дороге Из-под #футбол",
+        "enabled": true
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup in German",
+        "original": "\u0084Handwerk bringt dich überall hin\u0093: Von der YOU bis nach Monaco",
+        "fixed-encoding": "„Handwerk bringt dich überall hin“: Von der YOU bis nach Monaco",
+        "fixed": "\"Handwerk bringt dich überall hin\": Von der YOU bis nach Monaco",
+        "enabled": true
+    },
+    {
+        "label": "CESU-8 / Windows-1252 emoji",
+        "original": "Hi guys í ½í¸\u008d",
+        "fixed": "Hi guys 😍",
+        "enabled": true
+    },
+    {
+        "label": "CESU-8 / Latin-1 emoji",
+        "original": "hihi RT username: â\u0098ºí ½í¸\u0098",
+        "fixed": "hihi RT username: ☺😘",
+        "enabled": true
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup in Turkish",
+        "original": "Beta Haber: HÄ±rsÄ±zÄ± BÃ¼yÃ¼ Korkuttu",
+        "fixed": "Beta Haber: Hırsızı Büyü Korkuttu",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'è' preceded by a non-breaking space is not a small capital Y",
+        "original": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
+        "fixed": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Windows-1251 mixed up twice in Russian",
+        "original": "Р С—РЎР‚Р С‘РЎРЏРЎвЂљР Р…Р С•РЎРѓРЎвЂљР С‘. РІСњВ¤",
+        "fixed": "приятности. ❤",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixed up twice in Malay",
+        "original": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New Ã¢â‚¬Å“ RomanceÃ¢â‚¬Â\u009d.",
+        "fixed-encoding": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New “ Romance”.",
+        "fixed": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New \" Romance\".",
+        "enabled": true
+    },
+    {
+        "label": "Negative: accents are sometimes used as quotes",
+        "original": "``toda produzida pronta pra assa aí´´",
+        "fixed": "``toda produzida pronta pra assa aí´´",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'Õ' followed by an ellipsis",
+        "comment": "Should not turn into the Armenian letter Յ",
+        "original": "HUHLL Õ…",
+        "fixed": "HUHLL Õ…",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixed up twice in naming Iggy Pop",
+        "original": "Iggy Pop (nÃƒÂ© Jim Osterberg)",
+        "fixed": "Iggy Pop (né Jim Osterberg)",
+        "enabled": true
+    },
+    {
+        "label": "Left quote is UTF-8, right quote is Latin-1, both encoded in Windows-1252",
+        "original": "Direzione Pd, ok â\u0080\u009csenza modifiche\u0094 all'Italicum.",
+        "fixed-encoding": "Direzione Pd, ok “senza modifiche” all'Italicum.",
+        "fixed": "Direzione Pd, ok \"senza modifiche\" all'Italicum.",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / sloppy Windows-1252 mixed up twice in a triumphant emoticon",
+        "original": "selamat berpuasa sob (Ã\u00a0Â¸â€¡'ÃŒâ‚¬Ã¢Å’Â£'ÃŒÂ\u0081)Ã\u00a0Â¸â€¡",
+        "fixed": "selamat berpuasa sob (ง'̀⌣'́)ง",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixed up three times",
+        "original": "The Mona Lisa doesnÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢t have eyebrows.",
+        "fixed-encoding": "The Mona Lisa doesn’t have eyebrows.",
+        "fixed": "The Mona Lisa doesn't have eyebrows.",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Codepage 437 mixup in Russian",
+        "original": "#╨┐╤Ç╨░╨▓╨╕╨╗╤î╨╜╨╛╨╡╨┐╨╕╤é╨░╨╜╨╕╨╡",
+        "fixed": "#правильноепитание",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Windows-1250 mixup in French",
+        "original": "LiĂ¨ge Avenue de l'HĂ´pital",
+        "fixed": "Liège Avenue de l'Hôpital",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / sloppy Windows-1250 mixup in English",
+        "original": "It was namedÂ â€žscarsÂ´ stonesâ€ś after the rock-climbers who got hurt while climbing on it.",
+        "fixed-encoding": "It was named\u00a0„scars´ stones“ after the rock-climbers who got hurt while climbing on it.",
+        "fixed": "It was named\u00a0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it.",
+        "enabled": true
+    },
+    {
+        "label": "The same text as above, but as a UTF-8 / ISO-8859-2 mixup",
+        "original": "It was namedÂ\u00a0â\u0080\u009escarsÂ´ stonesâ\u0080\u009c after the rock-climbers who got hurt while climbing on it.",
+        "fixed-encoding": "It was named\u00a0„scars´ stones“ after the rock-climbers who got hurt while climbing on it.",
+        "fixed": "It was named\u00a0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it.",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / sloppy Windows-1250 mixup in Romanian",
+        "original": "vedere Ă®nceĹŁoĹźatÄ\u0083",
+        "fixed": "vedere înceţoşată",
+        "enabled": true
+    },
+    {
+        "label": "UTF-8 / Windows-1250 mixup in Slovak",
+        "original": "NapĂ\u00adĹˇte nĂˇm !",
+        "fixed": "Napíšte nám !",
+        "enabled": true
+    },
+    {
+        "label": "A face with UTF-8 / sloppy Windows-1252 mixed up twice",
+        "original": "Ã¢â€\u009dâ€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€\u009dÅ½",
+        "fixed": "┒(⌣˛⌣)┎",
+        "enabled": true
+    },
+    {
+        "label": "We can mostly decode the face above when we lose the character U+009D",
+        "original": "Ã¢â€�â€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€�Å½",
+        "fixed": "�(⌣˛⌣)�",
+        "enabled": true
+    },
+    {
+        "label": "CESU-8 / Latin-1 mixup over several emoji",
+        "comment": "You tried",
+        "original": "I just figured out how to tweet emojis! â\u009a½í\u00a0½í¸\u0080í\u00a0½í¸\u0081í\u00a0½í¸\u0082í\u00a0½í¸\u0086í\u00a0½í¸\u008eí\u00a0½í¸\u008eí\u00a0½í¸\u008eí\u00a0½í¸\u008e",
+        "fixed": "I just figured out how to tweet emojis! ⚽😀😁😂😆😎😎😎😎",
+        "enabled": true
+    },
+    {
+        "label": "Two levels of inconsistent mojibake",
+        "comment": "The en-dash was mojibaked in UTF-8 / Windows-1252 as three characters, two of which were mojibaked again as Windows-1252 / Latin-1, and the third of which was mojibaked as UTF-8 / Latin-1",
+        "original": "Arsenal v Wolfsburg: pre-season friendly â\u0080â\u0080\u009c live!",
+        "fixed": "Arsenal v Wolfsburg: pre-season friendly – live!",
+        "enabled": true
+    },
+    {
+        "label": "Negative: multiplication sign and ellipsis",
+        "comment": "Should not turn into a dot below",
+        "original": "4288×…",
+        "fixed": "4288×…",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'Ê' followed by an ellipsis",
+        "comment": "Should not turn into a squat reversed esh",
+        "original": "RETWEET SE VOCÊ…",
+        "fixed": "RETWEET SE VOCÊ…",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'É' followed by an ellipsis",
+        "comment": "Should not turn into 'MARQUɅ'",
+        "original": "PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…",
+        "fixed": "PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'Ó' followed by an ellipsis",
+        "comment": "Should not turn into 'SӅ'",
+        "original": "TEM QUE SEGUIR, SDV SÓ…",
+        "fixed": "TEM QUE SEGUIR, SDV SÓ…",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'É' followed by a curly apostrophe",
+        "comment": "Should not turn into 'ZZAJɒs'",
+        "original": "Join ZZAJÉ’s Official Fan List and receive news, events, and more!",
+        "fixed-encoding": "Join ZZAJÉ’s Official Fan List and receive news, events, and more!",
+        "fixed": "Join ZZAJÉ's Official Fan List and receive news, events, and more!",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'é' preceded by curly apostrophe",
+        "comment": "Should not turn into 'LՎpisode'",
+        "original": "L’épisode 8 est trop fou ouahh",
+        "fixed-encoding": "L’épisode 8 est trop fou ouahh",
+        "fixed": "L'épisode 8 est trop fou ouahh",
+        "enabled": true
+    },
+    {
+        "label": "Negative: three raised eyebrows or something?",
+        "comment": "Should not turn into private use character U+F659",
+        "original": "Ôôô VIDA MINHA",
+        "fixed": "Ôôô VIDA MINHA",
+        "enabled": true
+    },
+    {
+        "label": "Negative: copyright sign preceded by non-breaking space",
+        "comment": "Should not turn into 'ʩ'",
+        "original": "[x]\u00a0©",
+        "fixed": "[x]\u00a0©",
+        "enabled": true
+    },
+    {
+        "label": "Negative: en dash and infinity sign",
+        "comment": "Should not turn into '2012Ѱ'",
+        "original": "2012—∞",
+        "fixed": "2012—∞",
+        "enabled": true
+    },
+    {
+        "label": "Negative: This Е is a Ukrainian letter, but nothing else is wrong",
+        "original": "SENSЕ - Oleg Tsedryk",
+        "fixed": "SENSЕ - Oleg Tsedryk",
+        "enabled": true
+    },
+    {
+        "label": "Negative: angry face",
+        "comment": "The face should not turn into '`«'",
+        "original": "OK??:(   `¬´    ):",
+        "fixed": "OK??:(   `¬´    ):",
+        "enabled": true
+    },
+    {
+        "label": "Negative: triangle and degree sign",
+        "comment": "I'm not really sure what it *is* supposed to be, but it's not 'ơ'",
+        "original": "∆°",
+        "fixed": "∆°",
+        "enabled": true
+    },
+    {
+        "label": "Negative: Portuguese with inverted question mark",
+        "comment": "Former false positive - it should not turn into 'QUEM ɿ'",
+        "original": "ESSE CARA AI QUEM É¿",
+        "fixed": "ESSE CARA AI QUEM É¿",
+        "enabled": true
+    },
+    {
+        "label": "Negative: Portuguese with acute accents as quotation marks",
+        "comment": "Former false positive - the end should not turn into a superscript H",
+        "original": "``hogwarts nao existe, voce nao vai pegar o trem pra lá´´",
+        "fixed": "``hogwarts nao existe, voce nao vai pegar o trem pra lá´´",
+        "enabled": true
+    },
+    {
+        "label": "Negative: Finnish Ä followed by a non-breaking space",
+        "comment": "Former false positive - should not become a G with a dot",
+        "original": "SELKÄ\u00a0EDELLÄ\u00a0MAAHAN via @YouTube",
+        "fixed": "SELKÄ\u00a0EDELLÄ\u00a0MAAHAN via @YouTube",
+        "enabled": true
+    },
+    {
+        "label": "Negative: multiplying by currency",
+        "comment": "Former false positive - should not become the Hebrew letter 'final pe'",
+        "original": "Offering 5×£35 pin ups",
+        "fixed": "Offering 5×£35 pin ups",
+        "enabled": true
+    },
+    {
+        "label": "Negative: registered chocolate brand name",
+        "comment": "Former false positive - should not become the IPA letter 'lezh'",
+        "original": "NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional",
+        "fixed": "NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional",
+        "enabled": true
+    },
+
+    {
+        "label": "Punctuation pile-up should actually be musical notes",
+        "comment": "Unfortunately, the difference doesn't look convincing to ftfy",
+        "original": "Engkau masih yg terindah, indah di dalam hatikuâ™«~",
+        "fixed": "Engkau masih yg terindah, indah di dalam hatiku♫~",
+        "enabled": false
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixup in Gaelic involving non-breaking spaces",
+        "comment": "Too similar to the Finnish negative example with non-breaking spaces",
+        "original": "CÃ\u00a0nan nan GÃ\u00a0idheal",
+        "fixed": "Cànan nan Gàidheal",
+        "enabled": false
+    },
+    {
+        "label": "Windows-1252 / MacRoman mixup in Spanish",
+        "comment": "Requires something like encoding detection",
+        "original": "Deja dos heridos hundimiento de barco tur\u0092stico en Acapulco.",
+        "fixed": "Deja dos heridos hundimiento de barco turístico en Acapulco.",
+        "enabled": false
+    },
+    {
+        "label": "UTF-8 / Windows-1251 mixup in tweet spam",
+        "comment": "The Windows-1251-fixing plan is too conservative to fix this",
+        "original": "Blog Traffic Tip 2 вЂ“ Broadcast Email Your Blog",
+        "fixed": "Blog Traffic Tip 2 – Broadcast Email Your Blog",
+        "enabled": false
+    },
+    {
+        "label": "Negative: Leet line-art",
+        "comment": "Current false positive: it concidentally all decodes as UTF-8/CP437 mojibake and becomes 'ôaſaſaſaſa'",
+        "original": "├┤a┼┐a┼┐a┼┐a┼┐a",
+        "fixed": "├┤a┼┐a┼┐a┼┐a┼┐a",
+        "enabled": false
+    },
+
+    {
+        "label": "Synthetic, negative: Brontë's name does not end with a Korean syllable",
+        "comment": "The original example of why ftfy needs heuristics",
+        "original": "I'm not such a fan of Charlotte Brontë…”",
+        "fixed-encoding": "I'm not such a fan of Charlotte Brontë…”",
+        "fixed": "I'm not such a fan of Charlotte Brontë…\"",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic, negative: hypothetical Swedish product name",
+        "comment": "This used to be a constructed example of a false positive, until you added another symbol",
+        "original": "AHÅ™, the new sofa from IKEA",
+        "fixed": "AHÅ™, the new sofa from IKEA",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic, negative: Ukrainian capital letters",
+        "comment": "We need to fix Windows-1251 conservatively, or else this decodes as '²ʲ'",
+        "original": "ВІКІ is Ukrainian for WIKI",
+        "fixed": "ВІКІ is Ukrainian for WIKI",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic, negative: don't leak our internal use of byte 0x1A",
+        "comment": "We use byte 0x1A internally as an encoding of U+FFFD, but literal occurrences of U+1A are just ASCII control characters",
+        "original": "These control characters \u001a are apparently intentional \u0081",
+        "fixed-encoding": "These control characters \u001a are apparently intentional \u0081",
+        "fixed": "These control characters  are apparently intentional \u0081",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic, negative: U+1A on its own",
+        "comment": "We use byte 0x1A internally as an encoding of U+FFFD, but literal occurrences of U+1A are just ASCII control characters",
+        "original": "Here's a control character: \u001a",
+        "fixed-encoding": "Here's a control character: \u001a",
+        "fixed": "Here's a control character: ",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic, negative: A-with-circle as an Angstrom sign",
+        "comment": "Should not turn into '10 ŗ'",
+        "original": "a radius of 10 Å—",
+        "fixed": "a radius of 10 Å—",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic, negative: Spanish with exclamation points on the wrong sides",
+        "original": "!YO SÉ¡",
+        "fixed": "!YO SÉ¡",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic: fix text with backslashes in it",
+        "comment": "Tests for a regression on a long-ago bug",
+        "original": "<40\\% vs \u00e2\u0089\u00a540\\%",
+        "fixed": "<40\\% vs ≥40\\%",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic: curly quotes with mismatched encoding glitches in Latin-1",
+        "original": "\u00e2\u0080\u009cmismatched quotes\u0085\u0094",
+        "fixed-encoding": "“mismatched quotes…”",
+        "fixed": "\"mismatched quotes…\"",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic: curly quotes with mismatched encoding glitches in Windows-1252",
+        "original": "â€œmismatched quotesâ€¦”",
+        "fixed-encoding": "“mismatched quotes…”",
+        "fixed": "\"mismatched quotes…\"",
+        "enabled": true
+    },
+    {
+        "label": "Synthetic: lossy decoding in sloppy-windows-1252",
+        "original": "â€œlossy decodingâ€�",
+        "fixed-encoding": "“lossy decoding�",
+        "fixed": "\"lossy decoding�",
+        "enabled": true
+    }
+]

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -49,12 +49,6 @@
         "enabled": true
     },
     {
-        "label": "Negative: 'è' preceded by a non-breaking space is not a small capital Y",
-        "original": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
-        "fixed": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
-        "enabled": true
-    },
-    {
         "label": "UTF-8 / Windows-1251 mixed up twice in Russian",
         "original": "Р С—РЎР‚Р С‘РЎРЏРЎвЂљР Р…Р С•РЎРѓРЎвЂљР С‘. РІСњВ¤",
         "fixed": "приятности. ❤",
@@ -65,19 +59,6 @@
         "original": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New Ã¢â‚¬Å“ RomanceÃ¢â‚¬Â\u009d.",
         "fixed-encoding": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New “ Romance”.",
         "fixed": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New \" Romance\".",
-        "enabled": true
-    },
-    {
-        "label": "Negative: accents are sometimes used as quotes",
-        "original": "``toda produzida pronta pra assa aí´´",
-        "fixed": "``toda produzida pronta pra assa aí´´",
-        "enabled": true
-    },
-    {
-        "label": "Negative: 'Õ' followed by an ellipsis",
-        "comment": "Should not turn into the Armenian letter Յ",
-        "original": "HUHLL Õ…",
-        "fixed": "HUHLL Õ…",
         "enabled": true
     },
     {
@@ -171,10 +152,30 @@
         "enabled": true
     },
     {
+        "label": "Negative: 'è' preceded by a non-breaking space is not a small capital Y",
+        "original": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
+        "fixed": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
+        "enabled": true
+    },
+    {
         "label": "Negative: multiplication sign and ellipsis",
         "comment": "Should not turn into a dot below",
         "original": "4288×…",
         "fixed": "4288×…",
+        "enabled": true
+    },
+    {
+        "label": "Negative: accents are sometimes used as quotes",
+        "comment": "The CESU-8 decoder will try to decode this, and then fail when it hits the end of the string",
+        "original": "``toda produzida pronta pra assa aí´´",
+        "fixed": "``toda produzida pronta pra assa aí´´",
+        "enabled": true
+    },
+    {
+        "label": "Negative: 'Õ' followed by an ellipsis",
+        "comment": "Should not turn into the Armenian letter Յ",
+        "original": "HUHLL Õ…",
+        "fixed": "HUHLL Õ…",
         "enabled": true
     },
     {

--- a/tests/test_examples_in_json.py
+++ b/tests/test_examples_in_json.py
@@ -1,22 +1,27 @@
 """
-Test with text actually found in the wild (mostly on Twitter).
+Test ftfy's fixes using the data in `test_cases.json`.
 
-I collected test cases by listening to the Twitter streaming API for
-a million or so tweets, picking out examples with high weirdness according
-to ftfy version 2, and seeing what ftfy decoded them to. There are some
-impressive things that can happen to text, even in an ecosystem that is
-supposedly entirely UTF-8.
+I collected many test cases by listening to the Twitter streaming API for
+millions of tweets, picking out examples with high weirdness, and seeing what
+ftfy decoded them to. There are some impressive things that can happen to text,
+even in an ecosystem that is supposedly entirely UTF-8.
 
-TEST_CASES contains the most interesting examples of these, often with some
-trickiness of how to decode them into the actually intended text.
+Some examples come from the Common Crawl (particularly those involving
+Windows-1250 mojibake, which is more common on arbitrary Web pages than on
+Twitter), and some examples marked as 'synthetic' are contrived to test
+particular features of ftfy.
 
-For some reason, sampling Twitter gives no examples of text being
-accidentally decoded as Windows-1250, even though it's one of the more
-common encodings and this mojibake has been spotted in the wild. It may be
-that Windows-1250 is used in places that culturally don't use Twitter much
-(Central and Eastern Europe), and therefore nobody designs a Twitter app or
-bot to use Windows-1250. I've collected a couple of examples of
-Windows-1250 mojibake from elsewhere.
+Each test case is a dictionary containing the following items:
+
+- "label": a label that will identify the test case in nosetests
+- "original": the text to be ftfy'd
+- "fixed": what the result of ftfy.fix_text should be on this text
+
+There are also two optional fields:
+
+- "fixed-encoding": what the result of just ftfy.fix_encoding should be.
+  If missing, it will be considered to be the same as "fixed".
+- "comment": possibly-enlightening commentary on the test case.
 """
 from ftfy import fix_text
 from ftfy.fixes import fix_encoding_and_explain, apply_plan
@@ -70,7 +75,8 @@ def check_example(label):
     eq_(fix_text(extra_bad), fixed)
 
 
-def test_real_text():
+def test_cases():
+    # Run all the test cases in `test_cases.json`
     for test_case in TEST_DATA:
         if test_case['enabled']:
             label = test_case['label']

--- a/tests/test_examples_in_json.py
+++ b/tests/test_examples_in_json.py
@@ -35,29 +35,8 @@ TEST_FILENAME = os.path.join(THIS_DIR, 'test_cases.json')
 TEST_DATA = json.load(open(TEST_FILENAME, encoding='utf-8'))
 
 
-# We set up the tests as a dictionary where they can be looked up by label,
-# even though we already have them in a list, so we can call 'check_example' by
-# the test label. This will make the test label show up in the name of the test
-# in nose.
-
-def _make_tests():
-    available_tests = {}
-    for val in TEST_DATA:
-        label = val['label']
-        available_tests[label] = {
-            'original': val['original'],
-            'fixed': val['fixed'],
-            'fixed-encoding': val.get('fixed-encoding', val['fixed'])
-        }
-    return available_tests
-
-
-AVAILABLE_TESTS = _make_tests()
-
-
-def check_example(label):
-    # Run the test with the given label in the data file
-    val = AVAILABLE_TESTS[label]
+def check_example(val):
+    # Run one example from the data file
     orig = val['original']
     fixed = val['fixed']
 
@@ -68,7 +47,7 @@ def check_example(label):
 
     # Make sure we can decode the text as intended
     eq_(fix_text(orig), fixed)
-    eq_(encoding_fix, val['fixed-encoding'])
+    eq_(encoding_fix, val.get('fixed-encoding', val['fixed']))
 
     # Make sure we can decode as intended even with an extra layer of badness
     extra_bad = orig.encode('utf-8').decode('latin-1')
@@ -79,5 +58,5 @@ def test_cases():
     # Run all the test cases in `test_cases.json`
     for test_case in TEST_DATA:
         if test_case['enabled']:
-            label = test_case['label']
-            yield check_example, label
+            check_example.description = "test_examples_in_json.check_example({!r})".format(test_case['label'])
+            yield check_example, test_case

--- a/tests/test_examples_in_json.py
+++ b/tests/test_examples_in_json.py
@@ -47,7 +47,7 @@ def check_example(val):
 
     # Make sure we can decode the text as intended
     eq_(fix_text(orig), fixed)
-    eq_(encoding_fix, val.get('fixed-encoding', val['fixed']))
+    eq_(encoding_fix, val.get('fixed-encoding', fixed))
 
     # Make sure we can decode as intended even with an extra layer of badness
     extra_bad = orig.encode('utf-8').decode('latin-1')
@@ -58,5 +58,8 @@ def test_cases():
     # Run all the test cases in `test_cases.json`
     for test_case in TEST_DATA:
         if test_case['enabled']:
-            check_example.description = "test_examples_in_json.check_example({!r})".format(test_case['label'])
+            desc = "test_examples_in_json.check_example({!r})".format(
+                test_case['label']
+            )
+            check_example.description = desc
             yield check_example, test_case

--- a/tests/test_futuristic_codepoints.py
+++ b/tests/test_futuristic_codepoints.py
@@ -4,26 +4,6 @@ import sys
 from nose.tools import eq_
 
 
-def test_burritos():
-    # Make a string with two burritos in it. Python doesn't know about Unicode
-    # burritos, but ftfy can guess they're probably emoji anyway.
-    emoji_text = 'dos burritos: \U0001f32f\U0001f32f'
-
-    # Mangle the burritos into a mess of Cyrillic characters. (It would have
-    # been great if we could have decoded them in cp437 instead, to turn them
-    # into "DOS burritos", but the resulting string is one that ftfy has been
-    # able to fix even without knowledge of Unicode 9.)
-    emojibake = emoji_text.encode('utf-8').decode('windows-1251')
-
-    # Restore the original text.
-    eq_(fix_encoding(emojibake), emoji_text)
-
-    # This doesn't happen if we replace the burritos with arbitrary unassigned
-    # characters. The mangled text passes through as is.
-    not_emoji = 'dos burritos: \U0003f32f\U0003f32f'.encode('utf-8').decode('windows-1251')
-    eq_(fix_encoding(not_emoji), not_emoji)
-
-
 def test_unknown_emoji():
     # The range we accept as emoji has gotten larger. Let's make sure we can
     # decode the futuristic emoji U+1F960, which will probably be a picture of

--- a/tests/test_futuristic_codepoints.py
+++ b/tests/test_futuristic_codepoints.py
@@ -4,50 +4,6 @@ import sys
 from nose.tools import eq_
 
 
-phrases = [
-    "\u201CI'm not such a fan of Charlotte Brontë\u2026\u201D",
-    "\u201CI'm not such a fan of Charlotte Brontë\u2026\u201D",
-    "\u2039ALLÍ ESTÁ\u203A",
-    "\u2014ALLÍ ESTÁ\u2014",
-    "AHÅ™, the new sofa from IKEA®",
-    "ВІКІ is Ukrainian for WIKI",
-    'These control characters \x1a are apparently intentional \x81',
-    "I don't know what this is \x1a but this is the euro sign €",
-    "\u2014a radius of 10 Å\u2014",
-    # You can point out that these exclamation points are backwards. I know!
-    "!YO SÉ¡"
-
-]
-# These phrases should not be erroneously "fixed"
-def test_valid_phrases():
-    for phrase in phrases:
-        yield check_phrase, phrase
-
-
-def check_phrase(text):
-    # Check each valid phrase above, making sure that it doesn't get changed
-    eq_(fix_encoding(text), text)
-    eq_(fix_encoding(text.encode('utf-8').decode('latin-1')), text)
-
-    # make sure that the opening punctuation is not the only thing that makes
-    # it work
-    eq_(fix_encoding(text[1:]), text[1:])
-    eq_(fix_encoding(text[1:].encode('utf-8').decode('latin-1')), text[1:])
-
-
-def test_fix_with_backslash():
-    eq_(fix_encoding("<40\\% vs \xe2\x89\xa540\\%"), "<40\\% vs ≥40\\%")
-
-
-def test_mixed_utf8():
-    eq_(fix_encoding('\xe2\x80\x9cmismatched quotes\x85\x94'), '“mismatched quotes…”')
-    eq_(fix_encoding('â€œmismatched quotesâ€¦”'), '“mismatched quotes…”')
-
-
-def test_lossy_utf8():
-    eq_(fix_encoding('â€œlossy decodingâ€�'), '“lossy decoding�')
-
-
 def test_burritos():
     # Make a string with two burritos in it. Python doesn't know about Unicode
     # burritos, but ftfy can guess they're probably emoji anyway.

--- a/tests/test_real_text.py
+++ b/tests/test_real_text.py
@@ -1,138 +1,77 @@
+"""
+Test with text actually found in the wild (mostly on Twitter).
+
+I collected test cases by listening to the Twitter streaming API for
+a million or so tweets, picking out examples with high weirdness according
+to ftfy version 2, and seeing what ftfy decoded them to. There are some
+impressive things that can happen to text, even in an ecosystem that is
+supposedly entirely UTF-8.
+
+TEST_CASES contains the most interesting examples of these, often with some
+trickiness of how to decode them into the actually intended text.
+
+For some reason, sampling Twitter gives no examples of text being
+accidentally decoded as Windows-1250, even though it's one of the more
+common encodings and this mojibake has been spotted in the wild. It may be
+that Windows-1250 is used in places that culturally don't use Twitter much
+(Central and Eastern Europe), and therefore nobody designs a Twitter app or
+bot to use Windows-1250. I've collected a couple of examples of
+Windows-1250 mojibake from elsewhere.
+"""
 from ftfy import fix_text
 from ftfy.fixes import fix_encoding_and_explain, apply_plan
 from nose.tools import eq_
+import json
+import os
 
 
-TEST_CASES = [
-    ## These are excerpts from text actually seen in the wild, mostly on
-    ## Twitter. Usernames and links have been removed.
-    ("He's Justinâ¤", "He's Justin❤"),
-    ("Le Schtroumpf Docteur conseille g√¢teaux et baies schtroumpfantes pour un r√©gime √©quilibr√©.",
-     "Le Schtroumpf Docteur conseille gâteaux et baies schtroumpfantes pour un régime équilibré."),
-    ("âœ” No problems", "✔ No problems"),
-    ('4288×…', '4288×…'),
-    ('RETWEET SE VOCÊ…', 'RETWEET SE VOCÊ…'),
-    ('PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…', 'PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…'),
-    ('TEM QUE SEGUIR, SDV SÓ…', 'TEM QUE SEGUIR, SDV SÓ…'),
-    ('Join ZZAJÉ’s Official Fan List and receive news, events, and more!', "Join ZZAJÉ's Official Fan List and receive news, events, and more!"),
-    ('L’épisode 8 est trop fou ouahh', "L'épisode 8 est trop fou ouahh"),
-    ("РґРѕСЂРѕРіРµ РР·-РїРѕРґ #С„СѓС‚Р±РѕР»",
-     "дороге Из-под #футбол"),
-    ("\x84Handwerk bringt dich \xfcberall hin\x93: Von der YOU bis nach Monaco",
-     '"Handwerk bringt dich überall hin": Von der YOU bis nach Monaco'),
-    ("Hi guys í ½í¸", "Hi guys 😍"),
-    ("hihi RT username: âºí ½í¸",
-     "hihi RT username: ☺😘"),
-    ("Beta Haber: HÄ±rsÄ±zÄ± BÃ¼yÃ¼ Korkuttu",
-     "Beta Haber: Hırsızı Büyü Korkuttu"),
-    ("Ôôô VIDA MINHA", "Ôôô VIDA MINHA"),
-    ('[x]\xa0©', '[x]\xa0©'),
-    ('2012—∞', '2012—∞'),
-    ('Con il corpo e lo spirito ammaccato,\xa0è come se nel cuore avessi un vetro conficcato.',
-     'Con il corpo e lo spirito ammaccato,\xa0è come se nel cuore avessi un vetro conficcato.'),
-    ('Р С—РЎР‚Р С‘РЎРЏРЎвЂљР Р…Р С•РЎРѓРЎвЂљР С‘. РІСњВ¤', 'приятности. ❤'),
-    ('Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New Ã¢â‚¬Å“ RomanceÃ¢â‚¬Â.',
-     'Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New " Romance".'),
-    ("``toda produzida pronta pra assa aí´´", "``toda produzida pronta pra assa aí´´"),
-    ('HUHLL Õ…', 'HUHLL Õ…'),
-    ('Iggy Pop (nÃƒÂ© Jim Osterberg)', 'Iggy Pop (né Jim Osterberg)'),
-    ('eres mía, mía, mía, no te hagas la loca eso muy bien ya lo sabías',
-     'eres mía, mía, mía, no te hagas la loca eso muy bien ya lo sabías'),
-    ("Direzione Pd, ok âsenza modifiche all'Italicum.",
-     "Direzione Pd, ok \"senza modifiche\" all'Italicum."),
-    ('SENSЕ - Oleg Tsedryk', 'SENSЕ - Oleg Tsedryk'),   # this Е is a Ukrainian letter
-    ('OK??:(   `¬´    ):', 'OK??:(   `¬´    ):'),
-    ("selamat berpuasa sob (Ã\xa0Â¸â€¡'ÃŒâ‚¬Ã¢Å’Â£'ÃŒÂ\x81)Ã\xa0Â¸â€¡",
-     "selamat berpuasa sob (ง'̀⌣'́)ง"),
-    ("The Mona Lisa doesnÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢t have eyebrows.",
-     "The Mona Lisa doesn't have eyebrows."),
-    ("#╨┐╤Ç╨░╨▓╨╕╨╗╤î╨╜╨╛╨╡╨┐╨╕╤é╨░╨╜╨╕╨╡", "#правильноепитание"),
-    ('∆°', '∆°'),
+THIS_DIR = os.path.dirname(__file__)
+TEST_FILENAME = os.path.join(THIS_DIR, 'test_cases.json')
+TEST_DATA = json.load(open(TEST_FILENAME, encoding='utf-8'))
 
-    # Test Windows-1250 mixups
-    ("LiĂ¨ge Avenue de l'HĂ´pital", "Liège Avenue de l'Hôpital"),
-    ("It was namedÂ â€žscarsÂ´ stonesâ€ś after the rock-climbers who got hurt while climbing on it.",
-     "It was named\xa0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it."),
-    ("vedere Ă®nceĹŁoĹźatÄ\x83", "vedere înceţoşată"),
-    ("NapĂ\xadĹˇte nĂˇm !", "Napíšte nám !"),
 
-    # The second test is different in iso-8859-2
-    ("It was namedÂ\xa0â\x80\x9escarsÂ´ stonesâ\x80\x9c after the rock-climbers who got hurt while climbing on it.",
-     "It was named\xa0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it."),
+# We set up the tests as a dictionary where they can be looked up by label,
+# even though we already have them in a list, so we can call 'check_example' by
+# the test label. This will make the test label show up in the name of the test
+# in nose.
 
-    # This one has two differently-broken layers of Windows-1252 <=> UTF-8,
-    # and it's kind of amazing that we solve it.
-    ('Arsenal v Wolfsburg: pre-season friendly â\x80â\x80\x9c live!',
-     'Arsenal v Wolfsburg: pre-season friendly – live!'),
+def _make_tests():
+    available_tests = {}
+    for val in TEST_DATA:
+        label = val['label']
+        available_tests[label] = {
+            'original': val['original'],
+            'fixed': val['fixed'],
+            'fixed-encoding': val.get('fixed-encoding', val['fixed'])
+        }
+    return available_tests
 
-    # Test that we can mostly decode this face when the nonprintable
-    # character \x9d is lost
-    ('Ã¢â€\x9dâ€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€\x9dÅ½', '┒(⌣˛⌣)┎'),
-    ('Ã¢â€�â€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€�Å½', '�(⌣˛⌣)�'),
 
-    # You tried
-    ('I just figured out how to tweet emojis! â\x9a½í\xa0½í¸\x80í\xa0½í¸\x81í\xa0½í¸\x82í\xa0½í¸\x86í\xa0½í¸\x8eí\xa0½í¸\x8eí\xa0½í¸\x8eí\xa0½í¸\x8e',
-     'I just figured out how to tweet emojis! ⚽😀😁😂😆😎😎😎😎'),
+AVAILABLE_TESTS = _make_tests()
 
-    # Former false positives
-    ("ESSE CARA AI QUEM É¿", "ESSE CARA AI QUEM É¿"),
-    ("``hogwarts nao existe, voce nao vai pegar o trem pra lá´´", "``hogwarts nao existe, voce nao vai pegar o trem pra lá´´"),
-    ("SELKÄ\xa0EDELLÄ\xa0MAAHAN via @YouTube", "SELKÄ\xa0EDELLÄ\xa0MAAHAN via @YouTube"),
-    ("Offering 5×£35 pin ups", "Offering 5×£35 pin ups"),
-    ("NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional",
-     "NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional"),
 
-    ## This remains a false positive
-    # ("├┤a┼┐a┼┐a┼┐a┼┐a", "├┤a┼┐a┼┐a┼┐a┼┐a"),
+def check_example(label):
+    # Run the test with the given label in the data file
+    val = AVAILABLE_TESTS[label]
+    orig = val['original']
+    fixed = val['fixed']
 
-    ## This kind of tweet can't be fixed without a full-blown encoding detector.
-    #("Deja dos heridos hundimiento de barco tur\x92stico en Acapulco.",
-    # "Deja dos heridos hundimiento de barco turístico en Acapulco."),
+    # Make sure that the fix_encoding step outputs a plan that we can
+    # successfully run to reproduce its result
+    encoding_fix, plan = fix_encoding_and_explain(orig)
+    eq_(apply_plan(orig, plan), encoding_fix)
 
-    ## The original text looks too plausible
-    # ('CÃ\xa0nan nan GÃ\xa0idheal', 'Cànan nan Gàidheal'),
+    # Make sure we can decode the text as intended
+    eq_(fix_text(orig), fixed)
+    eq_(encoding_fix, val['fixed-encoding'])
 
-    ## Turning sorta-plausible text into musical notes isn't convincing enough
-    ## under the current heuristics
-    # ('Engkau masih yg terindah, indah di dalam hatikuâ™«~',
-    #  'Engkau masih yg terindah, indah di dalam hatiku♫~'),
-
-    ## The heuristics aren't confident enough to fix this text and its weird encoding.
-    #("Blog Traffic Tip 2 вЂ“ Broadcast Email Your Blog",
-    # "Blog Traffic Tip 2 – Broadcast Email Your Blog"),
-]
+    # Make sure we can decode as intended even with an extra layer of badness
+    extra_bad = orig.encode('utf-8').decode('latin-1')
+    eq_(fix_text(extra_bad), fixed)
 
 
 def test_real_text():
-    """
-    Test with text actually found in the wild (mostly on Twitter).
-
-    I collected test cases by listening to the Twitter streaming API for
-    a million or so tweets, picking out examples with high weirdness according
-    to ftfy version 2, and seeing what ftfy decoded them to. There are some
-    impressive things that can happen to text, even in an ecosystem that is
-    supposedly entirely UTF-8.
-
-    TEST_CASES contains the most interesting examples of these, often with some
-    trickiness of how to decode them into the actually intended text.
-
-    For some reason, sampling Twitter gives no examples of text being
-    accidentally decoded as Windows-1250, even though it's one of the more
-    common encodings and this mojibake has been spotted in the wild. It may be
-    that Windows-1250 is used in places that culturally don't use Twitter much
-    (Central and Eastern Europe), and therefore nobody designs a Twitter app or
-    bot to use Windows-1250. I've collected a couple of examples of
-    Windows-1250 mojibake from elsewhere.
-    """
-    for orig, target in TEST_CASES:
-        # make sure that the fix_encoding step outputs a plan that we can
-        # successfully run to reproduce its result
-        encoding_fix, plan = fix_encoding_and_explain(orig)
-        eq_(apply_plan(orig, plan), encoding_fix)
-
-        # make sure we can decode the text as intended
-        eq_(fix_text(orig), target)
-
-        # make sure we can decode as intended even with an extra layer of badness
-        extra_bad = orig.encode('utf-8').decode('latin-1')
-        eq_(fix_text(extra_bad), target)
+    for test_case in TEST_DATA:
+        if test_case['enabled']:
+            label = test_case['label']
+            yield check_example, label


### PR DESCRIPTION
A while ago, someone contacted me about wanting to port ftfy to Java (something I'd prefer to never have to do myself), and said that the test cases were helpful but were difficult to extract because of the fact that they're written in distinctly Python syntax.

In most cases it would be easy to copy string literals from one language to another... but this is ftfy. Uncooperative string literals are what it's *about*.

So here I've taken almost all of the tests that assert that `fix_text(A) == B`, both the "real text" and "synthetic" tests, and put them in one common JSON file, with metadata and a test runner that runs each test in such a way that it's identified by name in `nosetests`.

I left the tests that use Python's 8-digit Unicode escapes as they are, because the JSON version of those (two 4-digit Unicode escapes for the codepoint's surrogates) removes all the clarity that the Unicode escapes provide. These remain in a test file that's now called `test_futuristic_codepoints.py`.