### PR TITLE
Apostrophe fix

### DIFF
--- a/ftfy/chardata.py
+++ b/ftfy/chardata.py
@@ -117,7 +117,7 @@ LOSSY_UTF8_RE = re.compile(
 )
 
 # These regexes match various Unicode variations on single and double quotes.
-SINGLE_QUOTE_RE = re.compile('[\u2018-\u201b]')
+SINGLE_QUOTE_RE = re.compile('[\u02bc\u2018-\u201b]')
 DOUBLE_QUOTE_RE = re.compile('[\u201c-\u201f]')
 
 

--- a/ftfy/chardata.py
+++ b/ftfy/chardata.py
@@ -187,7 +187,8 @@ LIGATURES = {
     ord('ﬃ'): 'ffi',
     ord('ﬄ'): 'ffl',
     ord('ﬅ'): 'ſt',
-    ord('ﬆ'): 'st'
+    ord('ﬆ'): 'st',
+    ord('ŉ'): "ʼn",
 }
 
 

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -152,6 +152,13 @@
         "enabled": true
     },
     {
+        "label": "Handle Afrikaans 'n character",
+        "original": "ŉ Chloroplas is ŉ organel wat in fotosinterende plante voorkom.",
+        "fixed-encoding": "ŉ Chloroplas is ŉ organel wat in fotosinterende plante voorkom.",
+        "fixed": "'n Chloroplas is 'n organel wat in fotosinterende plante voorkom.",
+        "enabled": true
+    },
+    {
         "label": "Negative: 'è' preceded by a non-breaking space is not a small capital Y",
         "original": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
         "fixed": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",


### PR DESCRIPTION
Replace MODIFIER LETTER APOSTROPHE with a single quote, including in the deprecated Afrikaans digraph `ŉ`, which includes MODIFIER LETTER APOSTROPHE in its NFKC normalization.