### PR TITLE
Fix more Latin digraphs

### DIFF
--- a/ftfy/chardata.py
+++ b/ftfy/chardata.py
@@ -173,22 +173,39 @@ CONTROL_CHARS = _build_control_char_mapping()
 
 
 # A translate mapping that breaks ligatures made of Latin letters. While
-# ligatures may be important to the representation of other languages, in
-# Latin letters they tend to represent a copy/paste error.
+# ligatures may be important to the representation of other languages, in Latin
+# letters they tend to represent a copy/paste error. It omits ligatures such
+# as æ that are frequently used intentionally.
 #
-# Ligatures may also be separated by NFKC normalization, but that is sometimes
-# more normalization than you want.
+# This list additionally includes some Latin digraphs that represent two
+# characters for legacy encoding reasons, not for typographical reasons.
+#
+# Ligatures and digraphs may also be separated by NFKC normalization, but that
+# is sometimes more normalization than you want.
+
 LIGATURES = {
-    ord('Ĳ'): 'IJ',
+    ord('Ĳ'): 'IJ',   # Dutch ligatures
     ord('ĳ'): 'ij',
-    ord('ﬀ'): 'ff',
+    ord('ŉ'): "ʼn",   # Afrikaans digraph meant to avoid auto-curled quote
+    ord('Ǳ'): 'DZ',   # Serbian/Croatian digraphs for Cyrillic conversion
+    ord('ǲ'): 'Dz',
+    ord('ǳ'): 'dz',
+    ord('Ǆ'): 'DŽ',
+    ord('ǅ'): 'Dž',
+    ord('ǆ'): 'dž',
+    ord('Ǉ'): 'LJ',
+    ord('ǈ'): 'Lj',
+    ord('ǉ'): 'lj',
+    ord('Ǌ'): 'NJ',
+    ord('ǋ'): 'Nj',
+    ord('ǌ'): "nj",
+    ord('ﬀ'): 'ff',   # Latin typographical ligatures
     ord('ﬁ'): 'fi',
     ord('ﬂ'): 'fl',
     ord('ﬃ'): 'ffi',
     ord('ﬄ'): 'ffl',
     ord('ﬅ'): 'ſt',
     ord('ﬆ'): 'st',
-    ord('ŉ'): "ʼn",
 }
 
 

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -159,6 +159,13 @@
         "enabled": true
     },
     {
+        "label": "Handle Croatian single-codepoint digraphs",
+        "original": "izum „bootstrap load“ koji je korišteǌem polisilicijskog sloja proizveo dovoǉno dobre kondenzatore na čipu",
+        "fixed-encoding": "izum „bootstrap load“ koji je korišteǌem polisilicijskog sloja proizveo dovoǉno dobre kondenzatore na čipu",
+        "fixed": "izum \"bootstrap load\" koji je korištenjem polisilicijskog sloja proizveo dovoljno dobre kondenzatore na čipu",
+        "enabled": true
+    },
+    {
         "label": "Negative: 'è' preceded by a non-breaking space is not a small capital Y",
         "original": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
         "fixed": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",


### PR DESCRIPTION
While we're fixing the Afrikaans `ŉ` (as part of PR#84), we might as well fix other legacy Latin digraphs that we left out before because they weren't strictly ligatures -- the ones from Serbian/Croatian that only exist as codepoints to make a one-to-one mapping between Cyrillic and Latin characters in an old codepage.

Merge PR#84 first.