### PR TITLE
Use os.path.realpath, not os.path.abspath, to detect output filename collision.

### DIFF
--- a/ftfy/cli.py
+++ b/ftfy/cli.py
@@ -82,7 +82,7 @@ def main():
     if args.output == '-':
         outfile = sys.stdout
     else:
-        if os.path.abspath(args.output) == os.path.abspath(args.filename):
+        if os.path.realpath(args.output) == os.path.realpath(args.filename):
             sys.stderr.write(SAME_FILE_ERROR_TEXT)
             sys.exit(1)
         outfile = open(args.output, 'w', encoding='utf-8')


### PR DESCRIPTION
This strengthens the protections introduced in 11f7a2 against symbolic links.

Before:
```
(lumi)alin@analytics-0:~/tmp/realpath$ ls -l
total 8
lrwxrwxrwx 1 alin netusers    8 Jan  8 11:32 alias.txt -> real.txt
-rw-r--r-- 1 alin netusers 2819 Jan  8 11:34 real.txt
(lumi)alin@analytics-0:~/tmp/realpath$ ftfy real.txt -o new.txt
(lumi)alin@analytics-0:~/tmp/realpath$ ls -l
total 16
lrwxrwxrwx 1 alin netusers    8 Jan  8 11:32 alias.txt -> real.txt
-rw-r--r-- 1 alin netusers 2819 Jan  8 11:35 new.txt
-rw-r--r-- 1 alin netusers 2819 Jan  8 11:34 real.txt
(lumi)alin@analytics-0:~/tmp/realpath$ ftfy real.txt -o real.txt
ftfy error:
Can't read and write the same file. Please output to a new file instead.
(lumi)alin@analytics-0:~/tmp/realpath$ ftfy real.txt -o alias.txt
(lumi)alin@analytics-0:~/tmp/realpath$ ls -l
total 8
lrwxrwxrwx 1 alin netusers    8 Jan  8 11:32 alias.txt -> real.txt
-rw-r--r-- 1 alin netusers 2819 Jan  8 11:35 new.txt
-rw-r--r-- 1 alin netusers    0 Jan  8 11:35 real.txt
```

After:
```
(lumi)alin@analytics-0:~/tmp/realpath$ ls -l
total 8
lrwxrwxrwx 1 alin netusers    8 Jan  8 11:32 alias.txt -> real.txt
-rw-r--r-- 1 alin netusers 2819 Jan  8 11:35 real.txt
(lumi)alin@analytics-0:~/tmp/realpath$ ftfy real.txt -o new.txt
(lumi)alin@analytics-0:~/tmp/realpath$ ls -l
total 16
lrwxrwxrwx 1 alin netusers    8 Jan  8 11:32 alias.txt -> real.txt
-rw-r--r-- 1 alin netusers 2819 Jan  8 11:35 new.txt
-rw-r--r-- 1 alin netusers 2819 Jan  8 11:35 real.txt
(lumi)alin@analytics-0:~/tmp/realpath$ ftfy real.txt -o real.txt
ftfy error:
Can't read and write the same file. Please output to a new file instead.
(lumi)alin@analytics-0:~/tmp/realpath$ ftfy real.txt -o alias.txt                                                                                                                                           
ftfy error:
Can't read and write the same file. Please output to a new file instead.
```