### PR TITLE
The test case about a false positive wasn't a real false positive

### DIFF
--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -440,10 +440,10 @@
         "enabled": true
     },
     {
-        "label": "Synthetic, false positive: the Sami name of a town in Lapland, in capital letters, followed by a non-breaking space",
-        "comment": "Related testing tells me I should worry about cases like this, though I haven't seen a real example",
-        "original": "SUOVÂKUOŠKÂ\u00a0",
-        "fixed": "SUOVÂKUOŠKÂ\u00a0",
+        "label": "Synthetic, false positive: the title of a manga, in weird capitalized romaji, with a non-breaking space",
+        "comment": "Testing tells me I should worry about cases like this, though I haven't seen a real example. Searching for similar real text yields a lot of examples that actually come out fine.",
+        "original": "MISUTÂ\u00a0AJIKKO",
+        "fixed": "MISUTÂ\u00a0AJIKKO",
         "enabled": false
     },
     {


### PR DESCRIPTION
Just to be clear, this has no real effect because the test case is disabled anyway. But the thing the test case warned would happen didn't happen on that text, and we need some slightly less probable text to
make it happen.

It would have an effect if disabled test cases said what they currently turned into, as Andrew recommended.