### PR TITLE
Port test cases to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 build
 _build
 twitterlogs
+.eggs
+.pytest_cache

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --doctest-modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
     packages=['ftfy', 'ftfy.bad_codecs'],
     package_data={'ftfy': ['char_classes.dat']},
     install_requires=['wcwidth'],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",

--- a/tests/test_bytes.py
+++ b/tests/test_bytes.py
@@ -1,6 +1,6 @@
 from ftfy import guess_bytes
 from ftfy.bad_codecs.utf8_variants import IncrementalDecoder
-from nose.tools import eq_
+import pytest
 
 
 TEST_ENCODINGS = [
@@ -13,26 +13,24 @@ TEST_STRINGS = [
 ]
 
 
-def check_bytes_decoding(string):
+@pytest.mark.parametrize("string", TEST_STRINGS)
+def test_guess_bytes(string):
     for encoding in TEST_ENCODINGS:
         result_str, result_encoding = guess_bytes(string.encode(encoding))
-        eq_(result_str, string)
-        eq_(result_encoding, encoding)
+        assert result_str == string
+        assert result_encoding == encoding
 
     if '\n' in string:
         old_mac_bytes = string.replace('\n', '\r').encode('macroman')
         result_str, result_encoding = guess_bytes(old_mac_bytes)
-        eq_(result_str, string.replace('\n', '\r'))
+        assert result_str == string.replace('\n', '\r')
 
 
-def test_guess_bytes():
-    for string in TEST_STRINGS:
-        yield check_bytes_decoding, string
-
+def test_guess_bytes_null():
     bowdlerized_null = b'null\xc0\x80separated'
     result_str, result_encoding = guess_bytes(bowdlerized_null)
-    eq_(result_str, u'null\x00separated')
-    eq_(result_encoding, u'utf-8-variants')
+    assert result_str == u'null\x00separated'
+    assert result_encoding == u'utf-8-variants'
 
 
 def test_incomplete_sequences():
@@ -48,5 +46,5 @@ def test_incomplete_sequences():
         decoder = IncrementalDecoder()
         got = decoder.decode(left, final=False)
         got += decoder.decode(right)
-        eq_(got, test_string)
+        assert got == test_string
 

--- a/tests/test_bytes.py
+++ b/tests/test_bytes.py
@@ -29,8 +29,8 @@ def test_guess_bytes(string):
 def test_guess_bytes_null():
     bowdlerized_null = b'null\xc0\x80separated'
     result_str, result_encoding = guess_bytes(bowdlerized_null)
-    assert result_str == u'null\x00separated'
-    assert result_encoding == u'utf-8-variants'
+    assert result_str == 'null\x00separated'
+    assert result_encoding == 'utf-8-variants'
 
 
 def test_incomplete_sequences():

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -3,221 +3,221 @@
         "label": "Low-codepoint emoji",
         "original": "He's Justinâ\u009d¤",
         "fixed": "He's Justin❤",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / MacRoman mix-up about smurfs",
         "original": "Le Schtroumpf Docteur conseille g√¢teaux et baies schtroumpfantes pour un r√©gime √©quilibr√©.",
         "fixed": "Le Schtroumpf Docteur conseille gâteaux et baies schtroumpfantes pour un régime équilibré.",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Checkmark that almost looks okay as mojibake",
         "original": "âœ” No problems",
         "fixed": "✔ No problems",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1251 Russian mixup about futbol",
         "original": "РґРѕСЂРѕРіРµ Р\u0098Р·-РїРѕРґ #С„СѓС‚Р±РѕР»",
         "fixed": "дороге Из-под #футбол",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Latin-1 / Windows-1252 mixup in German",
         "original": "\u0084Handwerk bringt dich überall hin\u0093: Von der YOU bis nach Monaco",
         "fixed-encoding": "„Handwerk bringt dich überall hin“: Von der YOU bis nach Monaco",
         "fixed": "\"Handwerk bringt dich überall hin\": Von der YOU bis nach Monaco",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "CESU-8 / Windows-1252 emoji",
         "original": "Hi guys í ½í¸\u008d",
         "fixed": "Hi guys 😍",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "CESU-8 / Latin-1 emoji",
         "original": "hihi RT username: â\u0098ºí ½í¸\u0098",
         "fixed": "hihi RT username: ☺😘",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Latin-1 / Windows-1252 mixup in Turkish",
         "original": "Beta Haber: HÄ±rsÄ±zÄ± BÃ¼yÃ¼ Korkuttu",
         "fixed": "Beta Haber: Hırsızı Büyü Korkuttu",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1251 mixed up twice in Russian",
         "original": "Р С—РЎР‚Р С‘РЎРЏРЎвЂљР Р…Р С•РЎРѓРЎвЂљР С‘. РІСњВ¤",
         "fixed": "приятности. ❤",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1252 mixed up twice in Malay",
         "original": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New Ã¢â‚¬Å“ RomanceÃ¢â‚¬Â\u009d.",
         "fixed-encoding": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New “ Romance”.",
         "fixed": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New \" Romance\".",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1252 mixed up twice in naming Iggy Pop",
         "original": "Iggy Pop (nÃƒÂ© Jim Osterberg)",
         "fixed": "Iggy Pop (né Jim Osterberg)",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Left quote is UTF-8, right quote is Latin-1, both encoded in Windows-1252",
         "original": "Direzione Pd, ok â\u0080\u009csenza modifiche\u0094 all'Italicum.",
         "fixed-encoding": "Direzione Pd, ok “senza modifiche” all'Italicum.",
         "fixed": "Direzione Pd, ok \"senza modifiche\" all'Italicum.",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / sloppy Windows-1252 mixed up twice in a triumphant emoticon",
         "original": "selamat berpuasa sob (Ã\u00a0Â¸â€¡'ÃŒâ‚¬Ã¢Å’Â£'ÃŒÂ\u0081)Ã\u00a0Â¸â€¡",
         "fixed": "selamat berpuasa sob (ง'̀⌣'́)ง",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1252 mixed up three times",
         "original": "The Mona Lisa doesnÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢t have eyebrows.",
         "fixed-encoding": "The Mona Lisa doesn’t have eyebrows.",
         "fixed": "The Mona Lisa doesn't have eyebrows.",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Codepage 437 mixup in Russian",
         "original": "#╨┐╤Ç╨░╨▓╨╕╨╗╤î╨╜╨╛╨╡╨┐╨╕╤é╨░╨╜╨╕╨╡",
         "fixed": "#правильноепитание",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1250 mixup in French",
         "original": "LiĂ¨ge Avenue de l'HĂ´pital",
         "fixed": "Liège Avenue de l'Hôpital",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / sloppy Windows-1250 mixup in English",
         "original": "It was namedÂ â€žscarsÂ´ stonesâ€ś after the rock-climbers who got hurt while climbing on it.",
         "fixed-encoding": "It was named\u00a0„scars´ stones“ after the rock-climbers who got hurt while climbing on it.",
         "fixed": "It was named\u00a0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it.",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "The same text as above, but as a UTF-8 / ISO-8859-2 mixup",
         "original": "It was namedÂ\u00a0â\u0080\u009escarsÂ´ stonesâ\u0080\u009c after the rock-climbers who got hurt while climbing on it.",
         "fixed-encoding": "It was named\u00a0„scars´ stones“ after the rock-climbers who got hurt while climbing on it.",
         "fixed": "It was named\u00a0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it.",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / sloppy Windows-1250 mixup in Romanian",
         "original": "vedere Ă®nceĹŁoĹźatÄ\u0083",
         "fixed": "vedere înceţoşată",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1250 mixup in Slovak",
         "original": "NapĂ\u00adĹˇte nĂˇm !",
         "fixed": "Napíšte nám !",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "A face with UTF-8 / sloppy Windows-1252 mixed up twice",
         "original": "Ã¢â€\u009dâ€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€\u009dÅ½",
         "fixed": "┒(⌣˛⌣)┎",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "We can mostly decode the face above when we lose the character U+009D",
         "original": "Ã¢â€�â€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€�Å½",
         "fixed": "�(⌣˛⌣)�",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "CESU-8 / Latin-1 mixup over several emoji",
         "comment": "You tried",
         "original": "I just figured out how to tweet emojis! â\u009a½í\u00a0½í¸\u0080í\u00a0½í¸\u0081í\u00a0½í¸\u0082í\u00a0½í¸\u0086í\u00a0½í¸\u008eí\u00a0½í¸\u008eí\u00a0½í¸\u008eí\u00a0½í¸\u008e",
         "fixed": "I just figured out how to tweet emojis! ⚽😀😁😂😆😎😎😎😎",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Two levels of inconsistent mojibake",
         "comment": "The en-dash was mojibaked in UTF-8 / Windows-1252 as three characters, two of which were mojibaked again as Windows-1252 / Latin-1, and the third of which was mojibaked as UTF-8 / Latin-1",
         "original": "Arsenal v Wolfsburg: pre-season friendly â\u0080â\u0080\u009c live!",
         "fixed": "Arsenal v Wolfsburg: pre-season friendly – live!",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Handle Afrikaans 'n character",
         "original": "ŉ Chloroplas is ŉ organel wat in fotosinterende plante voorkom.",
         "fixed-encoding": "ŉ Chloroplas is ŉ organel wat in fotosinterende plante voorkom.",
         "fixed": "'n Chloroplas is 'n organel wat in fotosinterende plante voorkom.",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Handle Croatian single-codepoint digraphs",
         "original": "izum „bootstrap load“ koji je korišteǌem polisilicijskog sloja proizveo dovoǉno dobre kondenzatore na čipu",
         "fixed-encoding": "izum „bootstrap load“ koji je korišteǌem polisilicijskog sloja proizveo dovoǉno dobre kondenzatore na čipu",
         "fixed": "izum \"bootstrap load\" koji je korištenjem polisilicijskog sloja proizveo dovoljno dobre kondenzatore na čipu",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "A with an acute accent, in isolation",
         "original": "NicolÃ¡s",
         "fixed": "Nicolás",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: 'è' preceded by a non-breaking space is not a small capital Y",
         "original": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
         "fixed": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: multiplication sign and ellipsis",
         "comment": "Should not turn into a dot below",
         "original": "4288×…",
         "fixed": "4288×…",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: accents are sometimes used as quotes",
         "comment": "The CESU-8 decoder will try to decode this, and then fail when it hits the end of the string",
         "original": "``toda produzida pronta pra assa aí´´",
         "fixed": "``toda produzida pronta pra assa aí´´",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: 'Õ' followed by an ellipsis",
         "comment": "Should not turn into the Armenian letter Յ",
         "original": "HUHLL Õ…",
         "fixed": "HUHLL Õ…",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: 'Ê' followed by an ellipsis",
         "comment": "Should not turn into a squat reversed esh",
         "original": "RETWEET SE VOCÊ…",
         "fixed": "RETWEET SE VOCÊ…",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: 'É' followed by an ellipsis",
         "comment": "Should not turn into 'MARQUɅ'",
         "original": "PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…",
         "fixed": "PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: 'Ó' followed by an ellipsis",
         "comment": "Should not turn into 'SӅ'",
         "original": "TEM QUE SEGUIR, SDV SÓ…",
         "fixed": "TEM QUE SEGUIR, SDV SÓ…",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: 'É' followed by a curly apostrophe",
@@ -225,7 +225,7 @@
         "original": "Join ZZAJÉ’s Official Fan List and receive news, events, and more!",
         "fixed-encoding": "Join ZZAJÉ’s Official Fan List and receive news, events, and more!",
         "fixed": "Join ZZAJÉ's Official Fan List and receive news, events, and more!",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: 'é' preceded by curly apostrophe",
@@ -233,83 +233,83 @@
         "original": "L’épisode 8 est trop fou ouahh",
         "fixed-encoding": "L’épisode 8 est trop fou ouahh",
         "fixed": "L'épisode 8 est trop fou ouahh",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: three raised eyebrows or something?",
         "comment": "Should not turn into private use character U+F659",
         "original": "Ôôô VIDA MINHA",
         "fixed": "Ôôô VIDA MINHA",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: copyright sign preceded by non-breaking space",
         "comment": "Should not turn into 'ʩ'",
         "original": "[x]\u00a0©",
         "fixed": "[x]\u00a0©",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: en dash and infinity sign",
         "comment": "Should not turn into '2012Ѱ'",
         "original": "2012—∞",
         "fixed": "2012—∞",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: This Е is a Ukrainian letter, but nothing else is wrong",
         "original": "SENSЕ - Oleg Tsedryk",
         "fixed": "SENSЕ - Oleg Tsedryk",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: angry face",
         "comment": "The face should not turn into '`«'",
         "original": "OK??:(   `¬´    ):",
         "fixed": "OK??:(   `¬´    ):",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: triangle and degree sign",
         "comment": "I'm not really sure what it *is* supposed to be, but it's not 'ơ'",
         "original": "∆°",
         "fixed": "∆°",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: Portuguese with inverted question mark",
         "comment": "Former false positive - it should not turn into 'QUEM ɿ'",
         "original": "ESSE CARA AI QUEM É¿",
         "fixed": "ESSE CARA AI QUEM É¿",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: Portuguese with acute accents as quotation marks",
         "comment": "Former false positive - the end should not turn into a superscript H",
         "original": "``hogwarts nao existe, voce nao vai pegar o trem pra lá´´",
         "fixed": "``hogwarts nao existe, voce nao vai pegar o trem pra lá´´",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: Finnish Ä followed by a non-breaking space",
         "comment": "Former false positive - should not become a G with a dot",
         "original": "SELKÄ\u00a0EDELLÄ\u00a0MAAHAN via @YouTube",
         "fixed": "SELKÄ\u00a0EDELLÄ\u00a0MAAHAN via @YouTube",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: multiplying by currency",
         "comment": "Former false positive - should not become the Hebrew letter 'final pe'",
         "original": "Offering 5×£35 pin ups",
         "fixed": "Offering 5×£35 pin ups",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: registered chocolate brand name",
         "comment": "Former false positive - should not become the IPA letter 'lezh'",
         "original": "NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional",
         "fixed": "NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional",
-        "enabled": true
+        "expect": "pass"
     },
 
     {
@@ -317,41 +317,41 @@
         "comment": "Unfortunately, the difference doesn't look convincing to ftfy",
         "original": "Engkau masih yg terindah, indah di dalam hatikuâ™«~",
         "fixed": "Engkau masih yg terindah, indah di dalam hatiku♫~",
-        "enabled": false
+        "expect": "fail"
     },
     {
         "label": "UTF-8 / Windows-1252 mixup in Gaelic involving non-breaking spaces",
         "comment": "Too similar to the Finnish negative example with non-breaking spaces",
         "original": "CÃ\u00a0nan nan GÃ\u00a0idheal",
         "fixed": "Cànan nan Gàidheal",
-        "enabled": false
+        "expect": "fail"
     },
     {
         "label": "Windows-1252 / MacRoman mixup in Spanish",
         "comment": "Requires something like encoding detection",
         "original": "Deja dos heridos hundimiento de barco tur\u0092stico en Acapulco.",
         "fixed": "Deja dos heridos hundimiento de barco turístico en Acapulco.",
-        "enabled": false
+        "expect": "fail"
     },
     {
         "label": "UTF-8 / Windows-1251 mixup in tweet spam",
         "original": "Blog Traffic Tip 2 вЂ“ Broadcast Email Your Blog",
         "fixed": "Blog Traffic Tip 2 – Broadcast Email Your Blog",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "UTF-8 / Windows-1251 mixup",
         "original": "S&P Confirms UkrsotsbankвЂ™s вЂњB-вЂњ Rating",
         "fixed-encoding": "S&P Confirms Ukrsotsbank’s “B-“ Rating",
         "fixed": "S&P Confirms Ukrsotsbank's \"B-\" Rating",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Negative: Leet line-art",
         "comment": "Current false positive: it coincidentally all decodes as UTF-8/CP437 mojibake and becomes 'ôaſaſaſaſa'",
         "original": "├┤a┼┐a┼┐a┼┐a┼┐a",
         "fixed": "├┤a┼┐a┼┐a┼┐a┼┐a",
-        "enabled": false
+        "expect": "fail"
     },
 
     {
@@ -360,21 +360,21 @@
         "original": "I'm not such a fan of Charlotte Brontë…”",
         "fixed-encoding": "I'm not such a fan of Charlotte Brontë…”",
         "fixed": "I'm not such a fan of Charlotte Brontë…\"",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, negative: hypothetical Swedish product name",
         "comment": "This used to be a constructed example of a false positive, until you added another symbol",
         "original": "AHÅ™, the new sofa from IKEA",
         "fixed": "AHÅ™, the new sofa from IKEA",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, negative: Ukrainian capital letters",
         "comment": "We need to fix Windows-1251 conservatively, or else this decodes as '²ʲ'",
         "original": "ВІКІ is Ukrainian for WIKI",
         "fixed": "ВІКІ is Ukrainian for WIKI",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, negative: don't leak our internal use of byte 0x1A",
@@ -382,7 +382,7 @@
         "original": "These control characters \u001a are apparently intentional \u0081",
         "fixed-encoding": "These control characters \u001a are apparently intentional \u0081",
         "fixed": "These control characters  are apparently intentional \u0081",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, negative: U+1A on its own",
@@ -390,67 +390,67 @@
         "original": "Here's a control character: \u001a",
         "fixed-encoding": "Here's a control character: \u001a",
         "fixed": "Here's a control character: ",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, negative: A-with-circle as an Angstrom sign",
         "comment": "Should not turn into '10 ŗ'",
         "original": "a radius of 10 Å—",
         "fixed": "a radius of 10 Å—",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, negative: Spanish with exclamation points on the wrong sides",
         "original": "!YO SÉ¡",
         "fixed": "!YO SÉ¡",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic: fix text with backslashes in it",
         "comment": "Tests for a regression on a long-ago bug",
         "original": "<40\\% vs \u00e2\u0089\u00a540\\%",
         "fixed": "<40\\% vs ≥40\\%",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic: curly quotes with mismatched encoding glitches in Latin-1",
         "original": "\u00e2\u0080\u009cmismatched quotes\u0085\u0094",
         "fixed-encoding": "“mismatched quotes…”",
         "fixed": "\"mismatched quotes…\"",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic: curly quotes with mismatched encoding glitches in Windows-1252",
         "original": "â€œmismatched quotesâ€¦”",
         "fixed-encoding": "“mismatched quotes…”",
         "fixed": "\"mismatched quotes…\"",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic: lossy decoding in sloppy-windows-1252",
         "original": "â€œlossy decodingâ€�",
         "fixed-encoding": "“lossy decoding�",
         "fixed": "\"lossy decoding�",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, negative: Romanian word before a non-breaking space",
         "original": "NICIODATĂ\u00a0",
         "fixed": "NICIODATĂ\u00a0",
-        "enabled": true
+        "expect": "pass"
     },
     {
         "label": "Synthetic, false positive: the title of a manga, in weird capitalized romaji, with a non-breaking space",
         "comment": "Testing tells me I should worry about cases like this, though I haven't seen a real example. Searching for similar real text yields a lot of examples that actually come out fine.",
         "original": "MISUTÂ\u00a0AJIKKO",
         "fixed": "MISUTÂ\u00a0AJIKKO",
-        "enabled": false
+        "expect": "fail"
     },
     {
         "label": "Synthetic, negative: Camel-cased Serbian that looks like a UTF-8 / Windows-1251 mixup",
         "comment": "I made this text up, but it seems like it means 'HelloDevil'. Could be a username or something.",
         "original": "ПоздравЂаво",
         "fixed": "ПоздравЂаво",
-        "enabled": true
+        "expect": "pass"
     }
 ]

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -5,7 +5,6 @@ from ftfy.fixes import (
 from ftfy.badness import sequence_weirdness
 import unicodedata
 import sys
-from nose.tools import eq_
 
 
 # Most single-character strings which have been misencoded should be restored.
@@ -21,8 +20,8 @@ def test_bmp_characters():
                 garble2 = char.encode('utf-8').decode('latin-1').encode('utf-8').decode('latin-1')
                 for garb in (garble, garble2):
                     fixed, plan = fix_encoding_and_explain(garb)
-                    eq_(fixed, char)
-                    eq_(apply_plan(garb, plan), char)
+                    assert fixed == char
+                    assert apply_plan(garb, plan) == char
 
 
 def test_possible_encoding():
@@ -32,7 +31,7 @@ def test_possible_encoding():
 
 
 def test_byte_order_mark():
-    eq_(fix_encoding('ï»¿'), '\ufeff')
+    assert fix_encoding('ï»¿') == '\ufeff'
 
 
 def test_control_chars():
@@ -41,22 +40,22 @@ def test_control_chars():
         "\u206aget standardized\U000E0065\U000E006E.\r\n"
     )
     fixed = "Sometimes, bad ideas like these characters get standardized.\r\n"
-    eq_(remove_control_chars(text), fixed)
+    assert remove_control_chars(text) == fixed
 
 
 def test_emoji_variation_selector():
     # The hearts here are explicitly marked as emoji using the variation
     # selector U+FE0F. This is not weird.
-    eq_(sequence_weirdness('❤\ufe0f' * 10), 0)
+    assert sequence_weirdness('❤\ufe0f' * 10) == 0
 
 
 def test_emoji_skintone_selector():
     # Dear heuristic, you can't call skin-tone selectors weird anymore.
     # We welcome Santa Clauses of all colors.
-    eq_(sequence_weirdness('🎅🏿🎅🏽🎅🏼🎅🏻'), 0)
+    assert sequence_weirdness('🎅🏿🎅🏽🎅🏼🎅🏻') == 0
 
 
 def test_surrogates():
-    eq_(fix_surrogates('\udbff\udfff'), '\U0010ffff')
-    eq_(fix_surrogates('\ud800\udc00'), '\U00010000')
+    assert fix_surrogates('\udbff\udfff') == '\U0010ffff'
+    assert fix_surrogates('\ud800\udc00') == '\U00010000'
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import subprocess
 import os
-from nose.tools import eq_, assert_raises
+import pytest
 
 
 # Get the filename of 'halibote.txt', which contains some mojibake about
@@ -27,38 +27,37 @@ def get_command_output(args, stdin=None):
 
 def test_basic():
     output = get_command_output(['ftfy', TEST_FILENAME])
-    eq_(output, CORRECT_OUTPUT)
+    assert output == CORRECT_OUTPUT
 
 
 def test_guess_bytes():
     output = get_command_output(['ftfy', '-g', TEST_FILENAME])
-    eq_(output, CORRECT_OUTPUT)
+    assert output == CORRECT_OUTPUT
 
 
 def test_alternate_encoding():
     # The file isn't really in Windows-1252. But that's a problem ftfy
     # can fix, if it's allowed to be sloppy when reading the file.
     output = get_command_output(['ftfy', '-e', 'sloppy-windows-1252', TEST_FILENAME])
-    eq_(output, CORRECT_OUTPUT)
+    assert output == CORRECT_OUTPUT
 
 
 def test_wrong_encoding():
     # It's more of a problem when the file doesn't actually decode.
-    with assert_raises(subprocess.CalledProcessError) as context:
+    with pytest.raises(subprocess.CalledProcessError) as exception:
         get_command_output(['ftfy', '-e', 'windows-1252', TEST_FILENAME])
-    e = context.exception
-    eq_(e.output.decode('utf-8'), FAILED_OUTPUT)
+    assert exception.value.output.decode('utf-8') == FAILED_OUTPUT
 
 
 def test_same_file():
-    with assert_raises(subprocess.CalledProcessError) as context:
+    with pytest.raises(subprocess.CalledProcessError) as exception:
         get_command_output(['ftfy', TEST_FILENAME, '-o', TEST_FILENAME])
-    e = context.exception
-    assert e.output.decode('utf-8').startswith("ftfy error:\nCan't read and write the same file.")
+    error = exception.value.output.decode('utf-8')
+    assert error.startswith("ftfy error:\nCan't read and write the same file.")
 
 
 def test_stdin():
     with open(TEST_FILENAME, 'rb') as infile:
         output = get_command_output(['ftfy'], stdin=infile)
-        eq_(output, CORRECT_OUTPUT)
+        assert output == CORRECT_OUTPUT
 

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -1,15 +1,15 @@
 from ftfy import bad_codecs, guess_bytes
-from nose.tools import eq_
 
 
 def test_cesu8():
-    eq_(bad_codecs.search_function('cesu8').__class__,
-        bad_codecs.search_function('cesu-8').__class__)
+    cls1 = bad_codecs.search_function('cesu8').__class__
+    cls2 = bad_codecs.search_function('cesu-8').__class__
+    assert cls1 == cls2
 
     test_bytes = (b'\xed\xa6\x9d\xed\xbd\xb7 is an unassigned character, '
                   b'and \xc0\x80 is null')
     test_text = '\U00077777 is an unassigned character, and \x00 is null'
-    eq_(test_bytes.decode('cesu8'), test_text)
+    assert test_bytes.decode('cesu8') == test_text
 
 
 def test_russian_crash():

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,26 +1,25 @@
 from ftfy import fix_text, fix_text_segment
 from ftfy.fixes import unescape_html
-from nose.tools import eq_
 
 
 def test_entities():
     example = '&amp;\n<html>\n&amp;'
-    eq_(fix_text(example), '&\n<html>\n&amp;')
-    eq_(fix_text_segment(example), '&amp;\n<html>\n&amp;')
+    assert fix_text(example) == '&\n<html>\n&amp;'
+    assert fix_text_segment(example) == '&amp;\n<html>\n&amp;'
 
-    eq_(fix_text(example, fix_entities=True), '&\n<html>\n&')
-    eq_(fix_text_segment(example, fix_entities=True), '&\n<html>\n&')
+    assert fix_text(example, fix_entities=True) == '&\n<html>\n&'
+    assert fix_text_segment(example, fix_entities=True) == '&\n<html>\n&'
 
-    eq_(fix_text(example, fix_entities=False), '&amp;\n<html>\n&amp;')
-    eq_(fix_text_segment(example, fix_entities=False), '&amp;\n<html>\n&amp;')
+    assert fix_text(example, fix_entities=False) == '&amp;\n<html>\n&amp;'
+    assert fix_text_segment(example, fix_entities=False) == '&amp;\n<html>\n&amp;'
 
-    eq_(fix_text_segment('&lt;&gt;', fix_entities=False), '&lt;&gt;')
-    eq_(fix_text_segment('&lt;&gt;', fix_entities=True), '<>')
-    eq_(fix_text_segment('&lt;&gt;'), '<>')
-    eq_(fix_text_segment('jednocze&sacute;nie'), 'jednocześnie')
-    eq_(fix_text_segment('JEDNOCZE&Sacute;NIE'), 'JEDNOCZEŚNIE')
-    eq_(fix_text_segment('ellipsis&#133;', normalization='NFKC'), 'ellipsis...')
-    eq_(fix_text_segment('ellipsis&#x85;', normalization='NFKC'), 'ellipsis...')
-    eq_(fix_text_segment('broken&#x81;'), 'broken\x81')
-    eq_(unescape_html('euro &#x80;'), 'euro €')
-    eq_(unescape_html('not an entity &#20x6;'), 'not an entity &#20x6;')
+    assert fix_text_segment('&lt;&gt;', fix_entities=False) == '&lt;&gt;'
+    assert fix_text_segment('&lt;&gt;', fix_entities=True) == '<>'
+    assert fix_text_segment('&lt;&gt;') == '<>'
+    assert fix_text_segment('jednocze&sacute;nie') == 'jednocześnie'
+    assert fix_text_segment('JEDNOCZE&Sacute;NIE') == 'JEDNOCZEŚNIE'
+    assert fix_text_segment('ellipsis&#133;', normalization='NFKC') == 'ellipsis...'
+    assert fix_text_segment('ellipsis&#x85;', normalization='NFKC') == 'ellipsis...'
+    assert fix_text_segment('broken&#x81;') == 'broken\x81'
+    assert unescape_html('euro &#x80;') == 'euro €'
+    assert unescape_html('not an entity &#20x6;') == 'not an entity &#20x6;'

--- a/tests/test_examples_in_json.py
+++ b/tests/test_examples_in_json.py
@@ -34,24 +34,43 @@ THIS_DIR = os.path.dirname(__file__)
 TEST_FILENAME = os.path.join(THIS_DIR, 'test_cases.json')
 TEST_DATA = json.load(open(TEST_FILENAME, encoding='utf-8'))
 
+TESTS_THAT_PASS = [test for test in TEST_DATA if test['expect'] == 'pass']
+TESTS_THAT_FAIL = [test for test in TEST_DATA if test['expect'] == 'fail']
+
 
 @pytest.mark.parametrize("test_case", TEST_DATA)
+def test_well_formed_example(test_case):
+    assert test_case['expect'] in ('pass', 'fail')
+
+
+@pytest.mark.parametrize("test_case", TESTS_THAT_PASS)
 def test_json_example(test_case):
     # Run one example from the data file
-    if test_case['enabled']:
-        orig = test_case['original']
-        fixed = test_case['fixed']
+    orig = test_case['original']
+    fixed = test_case['fixed']
 
-        # Make sure that the fix_encoding step outputs a plan that we can
-        # successfully run to reproduce its result
-        encoding_fix, plan = fix_encoding_and_explain(orig)
-        assert apply_plan(orig, plan) == encoding_fix
+    # Make sure that the fix_encoding step outputs a plan that we can
+    # successfully run to reproduce its result
+    encoding_fix, plan = fix_encoding_and_explain(orig)
+    assert apply_plan(orig, plan) == encoding_fix
 
-        # Make sure we can decode the text as intended
-        assert fix_text(orig) == fixed
-        assert encoding_fix == test_case.get('fixed-encoding', fixed)
+    # Make sure we can decode the text as intended
+    assert fix_text(orig) == fixed
+    assert encoding_fix == test_case.get('fixed-encoding', fixed)
 
-        # Make sure we can decode as intended even with an extra layer of badness
-        extra_bad = orig.encode('utf-8').decode('latin-1')
-        assert fix_text(extra_bad) == fixed
+    # Make sure we can decode as intended even with an extra layer of badness
+    extra_bad = orig.encode('utf-8').decode('latin-1')
+    assert fix_text(extra_bad) == fixed
+
+
+@pytest.mark.parametrize("test_case", TESTS_THAT_FAIL)
+@pytest.mark.xfail(strict=True)
+def test_failing_json_example(test_case):
+    # Run an example from the data file that we believe will fail, due to
+    # ftfy's heuristic being insufficient
+    orig = test_case['original']
+    fixed = test_case['fixed']
+
+    encoding_fix, plan = fix_encoding_and_explain(orig)
+    assert encoding_fix == test_case.get('fixed-encoding', fixed)
 

--- a/tests/test_futuristic_codepoints.py
+++ b/tests/test_futuristic_codepoints.py
@@ -1,7 +1,6 @@
 from ftfy.fixes import fix_encoding
 from ftfy.badness import sequence_weirdness
 import sys
-from nose.tools import eq_
 
 
 def test_unknown_emoji():
@@ -10,26 +9,26 @@ def test_unknown_emoji():
     # a fortune cookie in Unicode 10.0:
     emoji_text = "\U0001f960 I see emoji in your future"
     emojibake = emoji_text.encode('utf-8').decode('windows-1252')
-    eq_(fix_encoding(emojibake), emoji_text)
+    assert fix_encoding(emojibake) == emoji_text
 
     # We believe enough in the future of this codepoint that we'll even
     # recognize it with a mangled byte A0
     emojibake = emojibake.replace('\xa0', ' ')
-    eq_(fix_encoding(emojibake), emoji_text)
+    assert fix_encoding(emojibake) == emoji_text
 
     # Increment the first byte to get a very similar test case, but a
     # codepoint that will definitely not exist anytime soon. In this case,
     # we consider the existing text, "ñŸ¥\xa0", to be more probable.
     not_emoji = "\U0005f960 I see mojibake in your present".encode('utf-8').decode('windows-1252')
-    eq_(fix_encoding(not_emoji), not_emoji)
+    assert fix_encoding(not_emoji) == not_emoji
 
 
 def test_unicode_9():
     # This string is 'bɪg'.upper() in Python 3.6 or later, containing the
     # new codepoint U+A7AE LATIN CAPITAL LETTER SMALL CAPITAL I.
-    eq_(sequence_weirdness("BꞮG"), 0)
+    assert sequence_weirdness("BꞮG") == 0
 
     # That should be less weird than having a definitely-unassigned character
     # in the string.
-    eq_(sequence_weirdness("B\U00090000G"), 2)
+    assert sequence_weirdness("B\U00090000G") == 2
 


### PR DESCRIPTION
The tests can now be run in a more modern way, using `pytest` (or `python setup.py test`) instead of `nosetests`.