### PR TITLE
Tweaks to detecting two-character mojibake sequences, especially with quotes (fixes #97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 5.3.1 (April 24, 2018)
+
+Packaging updates; provides better metadata for the new PyPI.
+
+
 ## Version 5.3 (January 25, 2018)
 
 - A heuristic has been too conservative since version 4.2, causing a regression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-## Version 5.3.1 (April 24, 2018)
+## Version 5.4 (June 1, 2018)
 
-Packaging updates; provides better metadata for the new PyPI.
+- ftfy was still too conservative about fixing short mojibake sequences,
+  such as "aoÃ»t" -> "août", when the broken version contained punctuation
+  such as curly or angle quotation marks.
+
+  The new heuristic observes in some cases that, even if quotation marks are
+  expected to appear next to letters, it is strange to have an accented capital
+  A before the quotation mark and more letters after the quotation mark.
+
+- Provides better metadata for the new PyPI.
 
 
 ## Version 5.3 (January 25, 2018)

--- a/ftfy/badness.py
+++ b/ftfy/badness.py
@@ -125,7 +125,10 @@ MOJIBAKE_SYMBOL_RE = re.compile(
     # Mojibake of low-numbered characters from ISO-8859-1 and, in some cases,
     # ISO-8859-2. This also covers some cases from related encodings such as
     # Windows-1252 and Windows-1250.
-    '[ÂÃĂ][\x80-\x9f€ƒ†‡ˆ‰Œ˜™œŸ¡¢£¤¥¦§¨ª¬¯°±²³µ¶·¸¹º¼½¾¿ˇ˘˝]|'
+    '[ÂÃĂ][\x80-\x9f€ƒ‚„†‡ˆ‰‹Œ“•˜œŸ¡¢£¤¥¦§¨ª«¬¯°±²³µ¶·¸¹º¼½¾¿ˇ˘˝]|'
+    # Characters we have to be a little more cautious about if they're at
+    # the end of a word, but totally okay to fix in the middle
+    '[ÂÃĂ][›»‘”©™]\w|'
     # ISO-8859-1, ISO-8859-2, or Windows-1252 mojibake of characters U+10000
     # to U+1FFFF. (The Windows-1250 and Windows-1251 versions might be too
     # plausible.)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ Python 2. Try this:
     pip install ftfy==4.4.3
 """
 
+DESCRIPTION = open('README.md').read()
+
 
 if sys.version_info[0] < 3:
     print(PY2_MESSAGE)
@@ -24,18 +26,21 @@ if sys.version_info[0] < 3:
 
 setup(
     name="ftfy",
-    version='5.3.0',
+    version='5.4.0',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     license="MIT",
     url='http://github.com/LuminosoInsight/python-ftfy',
     platforms=["any"],
     description="Fixes some problems with Unicode text after the fact",
+    long_description=DESCRIPTION,
+    long_description_content_type='text/markdown',
     packages=['ftfy', 'ftfy.bad_codecs'],
     package_data={'ftfy': ['char_classes.dat']},
     install_requires=['wcwidth'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
+    python_requires='>=3.3',
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
@@ -52,5 +57,8 @@ setup(
         'console_scripts': [
             'ftfy = ftfy.cli:main'
         ]
+    },
+    project_urls={
+        'Documentation': 'http://ftfy.readthedocs.io',
     }
 )

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -347,6 +347,20 @@
         "expect": "pass"
     },
     {
+        "label": "Dutch example with ë",
+        "comment": "from issue reported by MicroJackson",
+        "original": "ongeÃ«venaard",
+        "fixed-encoding": "ongeëvenaard",
+        "fixed": "ongeëvenaard",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Indonesian leetspeak",
+        "original": "MÄ£ÄM ÌÑÌ Q £ÄGÌ GÄLÄW ÑÍCH SÖÄ£ ÑÝÄ $ÚÄMÌ Q £ÄGÌ GÄK ÉÑÄK BÄDÄÑ....?????????,                     ......JÄDÍ...",
+        "fixed": "MÄ£ÄM ÌÑÌ Q £ÄGÌ GÄLÄW ÑÍCH SÖÄ£ ÑÝÄ $ÚÄMÌ Q £ÄGÌ GÄK ÉÑÄK BÄDÄÑ....?????????,                     ......JÄDÍ...",
+        "expect": "pass"
+    },
+    {
         "label": "Negative: Leet line-art",
         "comment": "Current false positive: it coincidentally all decodes as UTF-8/CP437 mojibake and becomes 'ôaſaſaſaſa'",
         "original": "├┤a┼┐a┼┐a┼┐a┼┐a",
@@ -434,9 +448,46 @@
         "expect": "pass"
     },
     {
+        "label": "Synthetic: French word for August in windows-1252",
+        "original": "aoÃ»t",
+        "fixed-encoding": "août",
+        "fixed": "août",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: French word for hotel in all-caps windows-1252",
+        "original": "HÃ”TEL",
+        "fixed-encoding": "HÔTEL",
+        "fixed": "HÔTEL",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Scottish Gaelic word for 'subject' in all-caps windows-1252",
+        "original": "CÃ™IS",
+        "fixed-encoding": "CÙIS",
+        "fixed": "CÙIS",
+        "expect": "pass"
+    },
+    {
         "label": "Synthetic, negative: Romanian word before a non-breaking space",
+        "comment": "The word literally means 'not even once', which might be a good recommendation about fixing Romanian mojibake",
         "original": "NICIODATĂ\u00a0",
         "fixed": "NICIODATĂ\u00a0",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Be careful around curly apostrophes",
+        "comment": "It shouldn't end up saying 'a lot of Òs'",
+        "original": "There are a lot of Ã’s in mojibake text",
+        "fixed-encoding": "There are a lot of Ã’s in mojibake text",
+        "fixed": "There are a lot of Ã's in mojibake text",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Romanian word before a trademark sign",
+        "comment": "We would change 'DATÃ™' to 'DATÙ', but getting windows-1250 involved makes it better to leave alone",
+        "original": "NICIODATĂ™",
+        "fixed": "NICIODATĂ™",
         "expect": "pass"
     },
     {
@@ -452,5 +503,12 @@
         "original": "ПоздравЂаво",
         "fixed": "ПоздравЂаво",
         "expect": "pass"
+    },
+    {
+        "label": "Synthetic, false negative: mojibake with trademark sign at the end of a word",
+        "comment": "I recall the correct version of this text from a sign in the movie Amélie. Unfortunately, we can't help her twin AmÃ©lie, who makes mojibaked signs.",
+        "original": "OÃ™ ET QUAND?",
+        "fixed": "OÙ ET QUAND?",
+        "expect": "fail"
     }
 ]


### PR DESCRIPTION
Fixing two-character mojibake sequences is a careful balance between
false positives and false negatives. This balance is maintained in
badness.py by `COMMON_SYMBOL_RE`, which lowers the badness of text
containing certain symbols, and `MOJIBAKE_SYMBOL_RE`, which raises the
badness in sequences that are very likely to be mojibake.

The badness was never raised again on sequences containing quotation
marks and a few other symbols, because I was overly cautious when adding
this rule. But issue #97 shows that this prevents fixing the most
common mojibake of words containing 'ë' or 'û'.

I've added these characters to the list of characters that are probably
mojibake if they appear after Â, Ã, or Ă:

    U+201A  ‚       SINGLE LOW-9 QUOTATION MARK
    U+201E  „       DOUBLE LOW-9 QUOTATION MARK
    U+2039  ‹       SINGLE LEFT-POINTING ANGLE QUOTATION MARK
    U+2018  ‘       LEFT SINGLE QUOTATION MARK
    U+201C  “       LEFT DOUBLE QUOTATION MARK
    U+201D  ”       RIGHT DOUBLE QUOTATION MARK
    U+2022  •       BULLET
    U+203A  ›       SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
    U+00AB  «       LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
    U+00BB  »       RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
    U+00A9  ©       COPYRIGHT SIGN

But I'm still leaving out these, which are too much risk for too little
gain:

    U+2019  ’       RIGHT SINGLE QUOTATION MARK
    U+00AE  ®       REGISTERED SIGN

Some characters have also been moved into a rule that insists on a
word-like character (`\w`) afterward, to make extra sure it's not
messing with normal punctuation.

See the new test cases for some cases that fall near the boundary of
what should be fixed.