### PR TITLE
Tweak the heuristic to be better at MacRoman

### DIFF
--- a/ftfy/badness.py
+++ b/ftfy/badness.py
@@ -129,6 +129,19 @@ MOJIBAKE_SYMBOL_RE = re.compile(
     # Characters we have to be a little more cautious about if they're at
     # the end of a word, but totally okay to fix in the middle
     '[ÂÃĂ][›»‘”©™]\w|'
+    # Similar mojibake of low-numbered characters in MacRoman. Leaving out
+    # most mathy characters because of false positives, but cautiously catching
+    # "√±" (mojibake for "ñ") and "√∂" (mojibake for "ö") in the middle of a
+    # word.
+    #
+    # I guess you could almost have "a√±b" in math, except that's not where
+    # you'd want the ±. Complex numbers don't quite work that way. "√±" appears
+    # unattested in equations in my Common Crawl sample.
+    #
+    # Also left out eye-like letters, including accented o's, for when ¬ is
+    # the nose of a kaomoji.
+    '[¬√][ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñúùûü†¢£§¶ß®©™≠ÆØ¥ªæø≤≥]|'
+    '\w√[±∂]\w|'
     # ISO-8859-1, ISO-8859-2, or Windows-1252 mojibake of characters U+10000
     # to U+1FFFF. (The Windows-1250 and Windows-1251 versions might be too
     # plausible.)

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -270,6 +270,12 @@
         "expect": "pass"
     },
     {
+        "label": "Negative, synthetic: face with glasses and a raised eyebrow",
+        "original": "( o¬ô )",
+        "fixed": "( o¬ô )",
+        "expect": "pass"
+    },
+    {
         "label": "Negative: triangle and degree sign",
         "comment": "I'm not really sure what it *is* supposed to be, but it's not 'ơ'",
         "original": "∆°",

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -361,13 +361,45 @@
         "expect": "pass"
     },
     {
+        "label": "Three layers of UTF-8 / MacRoman mixup in French",
+        "comment": "You're welcome",
+        "original": "Merci de t‚Äö√†√∂¬¨¬©l‚Äö√†√∂¬¨¬©charger le plug-in Flash Player 8",
+        "fixed": "Merci de télécharger le plug-in Flash Player 8",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / MacRoman mixup in French",
+        "original": "Merci de bien vouloir activiter le Javascript dans votre navigateur web afin d'en profiter‚Ä¶",
+        "fixed": "Merci de bien vouloir activiter le Javascript dans votre navigateur web afin d'en profiter…",
+        "expect": "pass"
+    },
+    {
+        "label": "Italian UTF-8 / MacRoman example with ò",
+        "original": "Le Vigne di Zam√≤",
+        "fixed": "Le Vigne di Zamò",
+        "expect": "pass"
+    },
+    {
+        "label": "Italian UTF-8 / MacRoman mojibake that looks like math",
+        "comment": "False negative: Dangerous to fix because of the following example",
+        "original": "Sarai ricontattato dal nostro Esperto al pi√π presto.",
+        "fixed": "Sarai ricontattato dal nostro Esperto al più presto.",
+        "expect": "fail"
+    },
+    {
+        "label": "Negative: math in Unicode",
+        "comment": "This isn't mojibake, it's an actual equation",
+        "original": "(-1/2)! = √π",
+        "fixed": "(-1/2)! = √π",
+        "expect": "pass"
+    },
+    {
         "label": "Negative: Leet line-art",
         "comment": "Current false positive: it coincidentally all decodes as UTF-8/CP437 mojibake and becomes 'ôaſaſaſaſa'",
         "original": "├┤a┼┐a┼┐a┼┐a┼┐a",
         "fixed": "├┤a┼┐a┼┐a┼┐a┼┐a",
         "expect": "fail"
     },
-
     {
         "label": "Synthetic, negative: Brontë's name does not end with a Korean syllable",
         "comment": "The original example of why ftfy needs heuristics",


### PR DESCRIPTION
Much like Windows-1252's tell-tale patterns involving `Â` or `Ã`, MacRoman leaves evidence of mojibake that starts with `¬` or `√`, and we can use this to be better at fixing borderline false negatives. However, we have to be careful of mathematical expressions like `√π`, and kaomoji like `( o¬ô )`.