### PR TITLE
Cope with different Python versions better in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,11 @@
-from setuptools import setup
 import sys
 
+# Before we get to the rest of setup, with dependencies on setuptools and the
+# Python 3 standard library, let's make sure we're not on Python 2 and provide
+# a helpful message if we are.
 
 PY2_MESSAGE = """
 Sorry, this version of ftfy is no longer written for Python 2.
-
-It is much easier to provide consistent handling of Unicode when developing
-only for Python 3. ftfy is exactly the kind of library that Python 3 is
-designed for, and now there is enough Python 3 usage that we can take advantage
-of it and write better, simpler code.
 
 The older version of ftfy, version 4.4, is still available and can run on
 Python 2. Try this:
@@ -16,13 +13,17 @@ Python 2. Try this:
     pip install ftfy==4.4.3
 """
 
-DESCRIPTION = open('README.md', encoding='utf-8').read()
-
-
 if sys.version_info[0] < 3:
     print(PY2_MESSAGE)
+    readable_version = sys.version.split(' ')[0]
+    print("The version of Python you're running is: %s" % readable_version)
+    print("Python is running from: %r" % sys.executable)
     sys.exit(1)
 
+
+from setuptools import setup
+
+DESCRIPTION = open('README.md', encoding='utf-8').read()
 
 setup(
     name="ftfy",
@@ -46,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
This provides a more helpful message when you attempt to install ftfy on
Python 2 (there used to be a message, but in recent versions it was
erroring before it got to print the message).

Because some instances of running Python 2 are now people who are trying
to run Python 3 and messed up their environment, the message now shows
details about what version of Python is running and where it came from.

This change also sets the Trove classifier that says that we support
Python 3.7.