### PR TITLE
Better detection of mojibake of low codepoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 5.8 (July 17, 2020)
+
+- Improved detection of UTF-8 mojibake of Greek, Cyrillic, Hebrew, and Arabic
+  scripts.
+
+- Fixed the undeclared dependency on setuptools by removing the use of
+  `pkg_resources`.
+
 ## Version 5.7 (February 18, 2020)
 
 - Updated the data file of Unicode character categories to Unicode 12.1, as

--- a/ftfy/badness.py
+++ b/ftfy/badness.py
@@ -167,7 +167,7 @@ MOJIBAKE_SYMBOL_RE = re.compile(
     # the multiplication sign. In the list of following characters, we exclude
     # currency symbols and numbers, which might actually be intended to be
     # multiplied.
-    r'×[\x80-\x9fƒ‚„†‡ˆ‰‹Œ“•˜œŸ¡¦§¨ª«¬¯°²³µ¶·¸¿ˇ˘˝›»‘”´©™]|'
+    '×[\x80-\x9fƒ‚„†‡ˆ‰‹Œ“•˜œŸ¡¦§¨ª«¬¯°²³µ¶·¸¿ˇ˘˝›»‘”´©™]|'
     
     # Similar mojibake of low-numbered characters in MacRoman. Leaving out
     # most mathy characters because of false positives, but cautiously catching

--- a/ftfy/badness.py
+++ b/ftfy/badness.py
@@ -118,20 +118,56 @@ COMMON_SYMBOL_RE = re.compile(
 # These are sequences that are common mojibake, resulting from common encodings
 # that are mixed up with UTF-8 on characters from their own character map.
 #
+# Sequences that match this regex will increase the `sequence_weirdness` of a
+# string.
+#
 # This helps to strengthen evidence that text should be fixed in a way that's
 # separate from the character classes above, or to counter COMMON_SYMBOL_RE's
 # fondness for characters such as inverted exclamation marks and multiplication
 # signs in contexts where they really do look like mojibake.
 
 MOJIBAKE_SYMBOL_RE = re.compile(
-    # Mojibake of low-numbered characters from ISO-8859-1 and, in some cases,
-    # ISO-8859-2. This also covers some cases from related encodings such as
-    # Windows-1252 and Windows-1250.
-    '[ÂÃĂ][\x80-\x9f€ƒ‚„†‡ˆ‰‹Œ“•˜œŸ¡¢£¤¥¦§¨ª«¬¯°±²³µ¶·¸¹º¼½¾¿ˇ˘˝]|'
+    # If the first character is in [ÂÃĂ], this covers mojibake of low-numbered
+    # characters from ISO-8859-1 and, in some cases, ISO-8859-2. This also
+    # covers some cases from related encodings such as Windows-1252 and
+    # Windows-1250.
+    # 
+    # The codepoints of decoded characters these correspond to are as follows:
+    #
+    #   Initial char.   Codepoints  What's in this range
+    #   -------------   ----------  --------------------
+    #   Â               80..BF      Latin-1 control characters and symbols
+    #   Ã, Ă            C0..FF      Latin-1 accented letters
+    #   Î               380..3BF    Greek letters
+    #   Ï, Ď            3C0..3FF    Greek letters
+    #   Ð, Đ            400..43F    Cyrillic letters
+    #   Ñ, Ń            440..47F    Cyrillic letters
+    #   Ø, Ř            600..63F    Arabic letters
+    #   Ù, Ů            640..67F    Arabic letters
+    #
+    # Here, we leave out Hebrew letters (which have a separate heuristic), and
+    # the rarer letters from each alphabet. This regex doesn't have to contain
+    # every character we want to decode -- just the sequences that we want to
+    # specifically detect as 'this looks like mojibake'.
+    # 
+    # We avoid ranges whose mojibake starts with characters like Ó -- which
+    # maps to Armenian and some more Cyrillic letters -- because those could be
+    # the 'eyes' of kaomoji faces.
+    #
+    # The set of possible second characters covers symbols that are unlikely to
+    # have a real meaning when following one of these capital letters, and appear
+    # as the second character in Latin-1, Windows-1250, or Windows-1252 mojibake.
+    '[ÂÃÎÏÐÑØÙĂĎĐŃŘŮ][\x80-\x9f€ƒ‚„†‡ˆ‰‹Œ“•˜œŸ¡¢£¤¥¦§¨ª«¬¯°±²³µ¶·¸¹º¼½¾¿ˇ˘˝]|'
     
     # Characters we have to be a little more cautious about if they're at
     # the end of a word, but totally okay to fix in the middle
-    r'[ÂÃĂ][›»‘”´©™]\w|'
+    r'[ÂÃÎÏÐÑØÙĂĎĐŃŘŮ][›»‘”´©™]\w|'
+
+    # Most Hebrew letters get mojibaked to two-character sequences that start with
+    # the multiplication sign. In the list of following characters, we exclude
+    # currency symbols and numbers, which might actually be intended to be
+    # multiplied.
+    r'×[\x80-\x9fƒ‚„†‡ˆ‰‹Œ“•˜œŸ¡¦§¨ª«¬¯°²³µ¶·¸¿ˇ˘˝›»‘”´©™]|'
     
     # Similar mojibake of low-numbered characters in MacRoman. Leaving out
     # most mathy characters because of false positives, but cautiously catching
@@ -146,6 +182,10 @@ MOJIBAKE_SYMBOL_RE = re.compile(
     # the nose of a kaomoji.
     '[¬√][ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñúùûü†¢£§¶ß®©™≠ÆØ¥ªæø≤≥]|'
     r'\w√[±∂]\w|'
+
+    # MacRoman mojibake of Hebrew involves a diamond character that is
+    # uncommon in intended text.
+    '◊|'
     
     # ISO-8859-1, ISO-8859-2, or Windows-1252 mojibake of characters U+10000
     # to U+1FFFF. (The Windows-1250 and Windows-1251 versions might be too

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ DESCRIPTION = open('README.md', encoding='utf-8').read()
 
 setup(
     name="ftfy",
-    version='5.7',
+    version='5.8',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     license="MIT",
@@ -34,10 +34,9 @@ setup(
     package_data={'ftfy': ['char_classes.dat']},
     install_requires=['wcwidth'],
     tests_require=['pytest'],
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -420,6 +420,43 @@
         "expect": "fail"
     },
     {
+        "label": "Hebrew UTF-8 / Windows-1252 mojibake",
+        "comment": "reported by SuperIRabbit as issue #158",
+        "original": "×‘×”×•×“×¢×”",
+        "fixed": "בהודעה",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Hebrew UTF-8 / Windows-1250 mojibake",
+        "original": "×‘×”×•×“×˘×”",
+        "fixed": "בהודעה",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Hebrew UTF-8 / MacRoman mojibake",
+        "original": "◊ë◊î◊ï◊ì◊¢◊î",
+        "fixed": "בהודעה",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Arabic UTF-8 / Windows-1252 mojibake",
+        "original": "Ø±Ø³Ø§Ù„Ø©",
+        "fixed": "رسالة",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Arabic UTF-8 / Windows-1250 mojibake",
+        "original": "Ř±ŘłŘ§Ů„Ř©",
+        "fixed": "رسالة",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Arabic UTF-8 / MacRoman mojibake",
+        "original": "ÿ±ÿ≥ÿßŸÑÿ©",
+        "fixed": "رسالة",
+        "expect": "pass"
+    },
+    {
         "label": "Negative: math in Unicode",
         "comment": "This isn't mojibake, it's an actual equation",
         "original": "(-1/2)! = √π",

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -439,6 +439,13 @@
         "expect": "pass"
     },
     {
+        "label": "Synthetic: Hebrew UTF-8 / Latin-1 mojibake",
+        "comment": "This example uses low-numbered codepoints to spell 'ABBA' in Hebrew, so that it falls into the range where Latin-1 is different from Windows-1252. As a bonus, this example looks right even if your RTL text rendering isn't working.",
+        "original": "×\u0090×\u0091×\u0091×\u0090",
+        "fixed": "אבבא",
+        "expect": "pass"
+    },
+    {
         "label": "Synthetic: Arabic UTF-8 / Windows-1252 mojibake",
         "original": "Ø±Ø³Ø§Ù„Ø©",
         "fixed": "رسالة",


### PR DESCRIPTION
We have a regex that's designed to say "this looks specifically like mojibake" that's part of the "weirdness" heuristic. It was detecting mojibake of the Latin-1 characters. We can make this work for some more scripts that also have low-numbered codepoints: Greek, Cyrillic, Hebrew, and Arabic.

We had a rule that was supposed to catch when Hebrew turns into multiplication signs -- but it wasn't working, because it wasn't
separated from the previous rule by `|`. Simply fixing that rule caused a test case to fail, so we need a larger heuristic.